### PR TITLE
Add scripts to provision a development virtual machine

### DIFF
--- a/doc/HOWTO.md
+++ b/doc/HOWTO.md
@@ -208,6 +208,93 @@ load Splunk's `tutorialdata.zip` data set as described in
 queries. It is also necessary if you intend to run the test suite, using
 `-Dcalcite.test.splunk=true`.)
 
+## Creating a development virtual machine
+
+To simplify testing of MongoDB, MySQL, PostgreSQL, and Splunk adapters,
+a virtual machine might be helpful.
+
+The step by step is as follows:
+  * Install <a href="https://www.vagrantup.com/">Vagrant</a>
+  * Install <a href="https://www.virtualbox.org/">Virtual Box</a>
+  * Ensure you have 5GiB space at host machine
+  * Provision a VM:
+```bash
+cd vm
+vagrant up # this will download base image and install all the databases
+```
+  * MongoDB zips and foodmart data are popupated during VM provision
+  * Populate MySQL and PostgreSQL databases with test data:
+```bash
+cd mondrian-loader
+mvn verify
+```
+
+Basic flow:
+  * Startup the VM: `vagrant up`
+  * Shutdown the VM: `vagrant halt`
+  * Rebuild the VM: `vagrant destroy`, then `vagrant up && cd mondrian-loader && mvn verify`
+
+### Accessing MongoDB in the VM
+Zips data:
+```bash
+$ vagrant ssh
+vagrant@ubuntucalcite:~$ mongo test
+MongoDB shell version: 2.6.6
+connecting to: test
+> show collections
+system.indexes
+zips
+```
+
+Foodmart data:
+```bash
+$ vagrant ssh
+vagrant@ubuntucalcite:~$ mongo foodmart
+MongoDB shell version: 2.6.6
+connecting to: foodmart
+> show collections
+account
+agg_c_10_sales_fact_1997
+agg_c_14_sales_fact_1997
+agg_c_special_sales_fact_1997
+agg_g_ms_pcat_sales_fact_1997
+...
+```
+
+### Accessing MySQL in the VM
+```bash
+$ vagrant ssh
+vagrant@ubuntucalcite:~$ mysql --user=foodmart --password=foodmart --database=foodmart
+...
+Server version: 5.5.40-0ubuntu0.14.04.1 (Ubuntu)
+...
+mysql> show tables
+    -> ;
++-------------------------------+
+| Tables_in_foodmart            |
++-------------------------------+
+| account                       |
+| agg_c_10_sales_fact_1997      |
+| agg_c_14_sales_fact_1997      |
+| agg_c_special_sales_fact_1997 |
+| agg_g_ms_pcat_sales_fact_1997 |
+...
+```
+
+### Accessing PostgreSQL in the VM
+```bash
+$ vagrant ssh
+vagrant@ubuntucalcite:~$ PGPASSWORD=foodmart PGHOST=localhost psql -U foodmart -d foodmart
+psql (9.3.5)
+foodmart=> \d
+ public | account                       | table | foodmart
+ public | agg_c_10_sales_fact_1997      | table | foodmart
+ public | agg_c_14_sales_fact_1997      | table | foodmart
+ public | agg_c_special_sales_fact_1997 | table | foodmart
+ public | agg_g_ms_pcat_sales_fact_1997 | table | foodmart
+...
+```
+
 ## Implementing an adapter
 
 New adapters can be created by implementing `OptiqPrepare.Context`:

--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -101,11 +101,8 @@ limitations under the License.
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
+        <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
-          <includes>
-            <include>org/apache/calcite/test/MongoAdapterTest.java</include>
-          </includes>
           <threadCount>6</threadCount>
           <parallel>both</parallel>
           <argLine>-Xmx1024m</argLine>

--- a/mongodb/src/test/java/org/apache/calcite/test/MongoAdapterIT.java
+++ b/mongodb/src/test/java/org/apache/calcite/test/MongoAdapterIT.java
@@ -56,7 +56,7 @@ import static org.junit.Assert.assertThat;
  * done<br>
  * </code></blockquote>
  */
-public class MongoAdapterTest {
+public class MongoAdapterIT {
   public static final String MONGO_FOODMART_SCHEMA = "     {\n"
       + "       type: 'custom',\n"
       + "       name: '_foodmart',\n"
@@ -103,20 +103,20 @@ public class MongoAdapterTest {
   /** Connection factory based on the "mongo-zips" model. */
   public static final ImmutableMap<String, String> ZIPS =
       ImmutableMap.of("model",
-          MongoAdapterTest.class.getResource("/mongo-zips-model.json")
+          MongoAdapterIT.class.getResource("/mongo-zips-model.json")
               .getPath());
 
   /** Connection factory based on the "mongo-zips" model. */
   public static final ImmutableMap<String, String> FOODMART =
       ImmutableMap.of("model",
-          MongoAdapterTest.class.getResource("/mongo-foodmart-model.json")
+          MongoAdapterIT.class.getResource("/mongo-foodmart-model.json")
               .getPath());
 
   /** Whether to run Mongo tests. Disabled by default, because we do not expect
-   * Mongo to be installed and populated with the FoodMart data set. To enable,
-   * specify {@code -Dcalcite.test.mongodb=true} on the Java command line. */
+   * Mongo to be installed and populated with the FoodMart data set. To disable,
+   * specify {@code -Dcalcite.test.mongodb=false} on the Java command line. */
   public static final boolean ENABLED =
-      Boolean.getBoolean("calcite.test.mongodb");
+      Boolean.valueOf(System.getProperty("calcite.test.mongodb", "true"));
 
   /** Whether to run this test. */
   protected boolean enabled() {
@@ -276,7 +276,7 @@ public class MongoAdapterTest {
         .query("select * from \"sales_fact_1997\"\n"
             + "union all\n"
             + "select * from \"sales_fact_1998\"")
-        .explainContains("PLAN=EnumerableUnionRel(all=[true])\n"
+        .explainContains("PLAN=EnumerableUnion(all=[true])\n"
             + "  MongoToEnumerableConverter\n"
             + "    MongoProject(product_id=[CAST(ITEM($0, 'product_id')):DOUBLE])\n"
             + "      MongoTableScan(table=[[_foodmart, sales_fact_1997]])\n"
@@ -714,4 +714,4 @@ public class MongoAdapterTest {
   }
 }
 
-// End MongoAdapterTest.java
+// End MongoAdapterIT.java

--- a/pom.xml
+++ b/pom.xml
@@ -377,6 +377,19 @@ limitations under the License.
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>2.16</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>integration-test</goal>
+                <goal>verify</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
           <version>2.1</version>
         </plugin>

--- a/vm/.gitignore
+++ b/vm/.gitignore
@@ -1,0 +1,2 @@
+.vagrant
+Puppetfile.lock

--- a/vm/Puppetfile
+++ b/vm/Puppetfile
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+forge 'https://forgeapi.puppetlabs.com'
+
+mod 'puppetlabs/mongodb'
+mod 'puppetlabs/mysql'
+mod 'puppetlabs/postgresql'
+mod 'example42/splunk'

--- a/vm/README.md
+++ b/vm/README.md
@@ -1,0 +1,13 @@
+## Creating a development virtual machine
+
+This is a set of scripts to create development virtual machine and populate it
+with test data.
+
+The following databases are created: MongoDB, MySQL, PostgreSQL.
+
+Requirements: Vagrant, Virtual Box.
+
+To create a VM, use the following command: `vagrant up && cd mondrian-loader && mvn verify`
+Fully-populated VM requires ~5GiB.
+
+For more information see Creating a development virtual machine in HOWTO

--- a/vm/Vagrantfile
+++ b/vm/Vagrantfile
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "puppetlabs/ubuntu-14.04-64-puppet"
+
+  config.vm.define :ubuntucalcite do |ubuntucalcite|
+    ubuntucalcite.vm.network :forwarded_port, guest: 27017, host: 27017 # mongodb
+    ubuntucalcite.vm.network :forwarded_port, guest: 5432, host: 5432 # postgresql
+    ubuntucalcite.vm.network :forwarded_port, guest: 3306, host: 3306 # mysql
+    ubuntucalcite.vm.network :forwarded_port, guest: 8089, host: 8089 # splunk
+
+    ubuntucalcite.vm.hostname = "ubuntucalcite"
+
+    ubuntucalcite.vm.provider :virtualbox do |v|
+      # This allows symlinks to be created within the /vagrant root directory,
+      # which is something librarian-puppet needs to be able to do. This might
+      # be enabled by default depending on what version of VirtualBox is used.
+      v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
+
+      v.customize ['modifyvm', :id, '--name', 'ubuntu1404-calcite']
+      v.customize ['modifyvm', :id, '--cpus', '1']
+      v.customize ['modifyvm', :id, '--memory', 512]
+      v.customize ['modifyvm', :id, '--ioapic', 'off']
+      v.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
+      v.customize ['modifyvm', :id, '--nictype1', 'virtio']
+      v.customize ['modifyvm', :id, '--nictype2', 'virtio']
+    end
+
+    ubuntucalcite.vm.provision :file, source: "Puppetfile", destination: "/home/vagrant/puppet/Puppetfile"
+    ubuntucalcite.vm.provision :shell, inline: "if [[ ! -f /apt-get-run ]]; then apt-get update && sudo touch /apt-get-run; fi"
+    ubuntucalcite.vm.provision :shell, inline: "apt-get install -y git-core ruby-dev unzip"
+    ubuntucalcite.vm.provision :shell, inline: "gem install --verbose librarian-puppet"
+    ubuntucalcite.vm.provision :shell, inline: "cd puppet && librarian-puppet install --verbose"
+    ubuntucalcite.vm.provision :shell, inline: "cd puppet && puppet apply -vv --modulepath=modules /vagrant/default.pp"
+
+    # Populate MongoDB
+    ubuntucalcite.vm.provision :shell, path: "init_mongodb.sh"
+  end
+end

--- a/vm/default.pp
+++ b/vm/default.pp
@@ -1,0 +1,83 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+node 'ubuntucalcite' {
+    # group { 'puppet': ensure => present }
+
+    Exec {
+        path => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/', '/usr/local/bin/' ],
+        logoutput => 'on_failure'
+    }
+
+    File { owner => 0, group => 0, mode => 0644 }
+
+    # Mongo
+    # This should install mongodb server and client, in the latest mongodb-org version
+    class {'::mongodb::globals':
+        manage_package_repo => true,
+        server_package_name => 'mongodb-org'
+    } ->
+    class {'::mongodb::server':
+        journal => true,
+        bind_ip => ['0.0.0.0'],
+    } ->
+    class {'::mongodb::client':
+    }
+
+    # MySQL
+    class {'::mysql::server':
+      root_password    => 'strongpassword',
+      override_options => {
+        'mysqld' => {
+          'bind-address' => '0.0.0.0'
+        }
+      },
+      restart => true,
+    }
+    class {'::mysql::client':
+    }
+    # Create foodmart database
+    mysql::db {'foodmart':
+      user     => 'foodmart',
+      password => 'foodmart',
+      host     => '%',
+      grant    => ['ALL'],
+    }
+
+    # PostgreSQL 9.3 server
+    class {'::postgresql::globals':
+      version => '9.3',
+      manage_package_repo => true,
+      encoding => 'UTF8',
+      locale  => 'en_US.utf8',
+    } ->
+    class {'::postgresql::server':
+      service_ensure => true,
+      listen_addresses => '*',
+      ip_mask_allow_all_users => '0.0.0.0/0',
+      ipv4acls => ['local all all md5'],
+    }
+    # Create postgresql database
+    postgresql::server::db {'foodmart':
+      user     => 'foodmart',
+      password => postgresql_password('foodmart', 'foodmart'),
+    }
+}
+
+node 'ubuntucalcite-not-yet-ready' {
+  class {"splunk":
+    install => "server",
+  }
+}

--- a/vm/init_mongodb.sh
+++ b/vm/init_mongodb.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is called automatically by Vagrant VM provision
+
+echo Importing zips dataset
+if [[ ! -f /tmp/zips.json ]]; then
+  curl -s -o /tmp/zips.json http://media.mongodb.org/zips.json
+fi
+mongoimport --db test --collection zips --file /tmp/zips.json
+
+echo Importing foodmart dataset
+if [[ ! -f /tmp/foodmart-json.jar ]]; then
+  curl -s -o /tmp/foodmart-json.jar http://nexus.pentaho.org/content/groups/omni/pentaho/mondrian-data-foodmart-json/0.3.3/mondrian-data-foodmart-json-0.3.3.jar
+fi
+
+unzip -u /tmp/foodmart-json.jar -d /tmp/mongodb-foodmart
+cd /tmp/mongodb-foodmart
+for i in *.json; do
+  echo .. importing $i
+  mongoimport --db foodmart --collection ${i/.json/} --file $i
+done
+
+echo Importing additional test collections
+mongo test <<JSON
+  db.createCollection("datatypes")
+  db.datatypes.insert({
+    "_id" : ObjectId("53655599e4b0c980df0a8c27"),
+    "_class" : "com.ericblue.Test",
+    "date" : ISODate("2012-09-05T07:00:00Z"),
+    "value" : 1231,
+    "ownerId" : "531e7789e4b0853ddb861313"
+  })
+JSON

--- a/vm/mondrian-loader/pom.xml
+++ b/vm/mondrian-loader/pom.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.calcite</groupId>
+  <artifactId>calcite-foodmart-loader</artifactId>
+  <packaging>pom</packaging>
+  <version>1.0.0-incubating-SNAPSHOT</version>
+  <name>Calcite foodmart data loader</name>
+  <description>Test data loader</description>
+
+  <repositories>
+    <repository>
+      <id>pentaho-repo</id>
+      <name>pentaho repository</name>
+      <url>http://ivy-nexus.pentaho.org/content/groups/omni</url>
+    </repository>
+  </repositories>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.3.2</version>
+        <executions>
+          <execution>
+            <id>foodmart-mysql</id>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <phase>integration-test</phase>
+            <configuration>
+              <mainClass>mondrian.test.loader.MondrianFoodMartLoader</mainClass>
+              <arguments>
+                <argument>-tables</argument>
+                <argument>-data</argument>
+                <argument>-indexes</argument>
+                <argument>-jdbcDrivers=com.mysql.jdbc.Driver</argument>
+                <argument>-inputFile=target/FoodMartCreateData.zip</argument>
+                <argument>-outputJdbcURL=jdbc:mysql://localhost/foodmart?user=foodmart&amp;password=foodmart</argument>
+              </arguments>
+              <systemProperties>
+                <systemProperty>
+                  <key>log4j.configuration</key>
+                  <value>file:src/main/resources/log4j.properties</value>
+                </systemProperty>
+              </systemProperties>
+            </configuration>
+          </execution>
+          <execution>
+            <id>foodmart-postgresql</id>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <phase>integration-test</phase>
+            <configuration>
+              <mainClass>mondrian.test.loader.MondrianFoodMartLoader</mainClass>
+              <arguments>
+                <argument>-tables</argument>
+                <argument>-data</argument>
+                <argument>-indexes</argument>
+                <argument>-jdbcDrivers=org.postgresql.Driver</argument>
+                <argument>-inputFile=target/FoodMartCreateData.zip</argument>
+                <argument>-outputJdbcURL=jdbc:postgresql://localhost/foodmart?user=foodmart&amp;password=foodmart</argument>
+              </arguments>
+              <systemProperties>
+                <systemProperty>
+                  <key>log4j.configuration</key>
+                  <value>file:src/main/resources/log4j.properties</value>
+                </systemProperty>
+              </systemProperties>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <version>5.1.34</version>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>9.3-1102-jdbc3</version>
+    </dependency>
+    <dependency>
+      <groupId>pentaho</groupId>
+      <artifactId>mondrian</artifactId>
+      <version>3.8.1.0-148</version>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>download-foodmart</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+        <file><missing>target/FoodMartCreateData.zip</missing></file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>wagon-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>download-foodmart-data</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>download-single</goal>
+                </goals>
+                <configuration>
+                  <serverId>github</serverId>
+                  <url>https://github.com/pentaho/mondrian/raw/master/demo</url>
+                  <fromFile>FoodMartCreateData.zip</fromFile>
+                  <toDir>target</toDir>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/vm/mondrian-loader/src/main/resources/log4j.properties
+++ b/vm/mondrian-loader/src/main/resources/log4j.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+log4j.rootLogger=INFO, stdout
+
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n


### PR DESCRIPTION
Prerequisites: Vagrant, VirtualBox, 5GiB of disk space and 30 minutes.

One-liner to spin up a VM: `cd vm && vagrant up && cd mondrian-loader && mvn verify`

`mvn test` works as usual.
To launch end-to-end tests (e.g. including MongoDB), use `mvn verify`.

14 of 27 mongo tests fail mainly due to newer zips dataset.