### PR TITLE
[CALCITE-628]: Ensure target traits are simple when use Frameworks or Re...

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptRule.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptRule.java
@@ -490,14 +490,15 @@ public abstract class RelOptRule {
    */
   public static RelNode convert(RelNode rel, RelTraitSet toTraits) {
     RelOptPlanner planner = rel.getCluster().getPlanner();
+    RelTraitSet toSimpleTraits = toTraits.simplify();
 
-    if (rel.getTraitSet().size() < toTraits.size()) {
-      new RelTraitPropagationVisitor(planner, toTraits).go(rel);
+    if (rel.getTraitSet().size() < toSimpleTraits.size()) {
+      new RelTraitPropagationVisitor(planner, toSimpleTraits).go(rel);
     }
 
     RelTraitSet outTraits = rel.getTraitSet();
-    for (int i = 0; i < toTraits.size(); i++) {
-      RelTrait toTrait = toTraits.getTrait(i);
+    for (int i = 0; i < toSimpleTraits.size(); i++) {
+      RelTrait toTrait = toSimpleTraits.getTrait(i);
       if (toTrait != null) {
         outTraits = outTraits.replace(i, toTrait);
       }

--- a/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
@@ -253,9 +253,10 @@ public class PlannerImpl implements Planner {
 
   public RelNode transform(int ruleSetIndex, RelTraitSet requiredOutputTraits,
       RelNode rel) throws RelConversionException {
+    RelTraitSet designedTraitSet = requiredOutputTraits.simplify();
     ensure(State.STATE_5_CONVERTED);
     Program program = programs.get(ruleSetIndex);
-    return program.run(planner, rel, requiredOutputTraits);
+    return program.run(planner, rel, designedTraitSet);
   }
 
   /** Stage of a statement in the query-preparation lifecycle. */


### PR DESCRIPTION

1. The new testcase uses some code in Jacques's CALCITE-606 patch.  

2. The new testcase would fail at Assertion at RelSubset:108, if reverse the changes to PlannerImpl.transform() or RelOptRule.convert().