### PR TITLE
718 cursor fetch

### DIFF
--- a/avatica-server/src/main/java/org/apache/calcite/avatica/jdbc/JdbcMeta.java
+++ b/avatica-server/src/main/java/org/apache/calcite/avatica/jdbc/JdbcMeta.java
@@ -712,9 +712,11 @@ public class JdbcMeta implements Meta {
   public ExecuteResult prepareAndExecute(StatementHandle statementHandle, String sql,
       int maxRowCount, PrepareCallback callback) {
     try {
-      final StatementInfo statementInfo = Objects.requireNonNull(
-          statementCache.getIfPresent(statementHandle.id),
-          "Statement not found, potentially expired. " + statementHandle);
+      final StatementInfo statementInfo = statementCache.getIfPresent(statementHandle.id);
+      if (statementInfo == null) {
+        throw new RuntimeException("Statement not found, potentially expired. "
+          + statementHandle);
+      }
       final Statement statement = statementInfo.statement;
       // Special handling of maxRowCount as JDBC 0 is unlimited, our meta 0 row
       if (maxRowCount > 0 || maxRowCount == -1) {

--- a/avatica-server/src/main/java/org/apache/calcite/avatica/jdbc/JdbcMeta.java
+++ b/avatica-server/src/main/java/org/apache/calcite/avatica/jdbc/JdbcMeta.java
@@ -713,11 +713,14 @@ public class JdbcMeta implements Meta {
       int maxRowCount, PrepareCallback callback) {
     try {
       final Connection connection = getConnection(ch.id);
-      final PreparedStatement statement = connection.prepareStatement(sql);
+      final Statement statement = connection.createStatement();
       final int id = System.identityHashCode(statement);
       final StatementInfo info = new StatementInfo(statement);
       statementCache.put(id, info); // TODO: must we retain a statement in all cases?
-      boolean ret = statement.execute();
+      if (maxRowCount > 0) {
+        statement.setMaxRows(maxRowCount);
+      }
+      boolean ret = statement.execute(sql);
       info.resultSet = statement.getResultSet();
       assert ret || info.resultSet == null;
       final List<MetaResultSet> resultSets = new ArrayList<>();
@@ -726,7 +729,7 @@ public class JdbcMeta implements Meta {
         resultSets.add(
             MetaResultSet.count(ch.id, id, statement.getUpdateCount()));
       } else {
-        resultSets.add(JdbcResultSet.create(ch.id, id, info.resultSet));
+        resultSets.add(JdbcResultSet.create(ch.id, id, info.resultSet, maxRowCount));
       }
       if (LOG.isTraceEnabled()) {
         StatementHandle h = new StatementHandle(ch.id, id, null);

--- a/avatica-server/src/main/java/org/apache/calcite/avatica/jdbc/JdbcResultSet.java
+++ b/avatica-server/src/main/java/org/apache/calcite/avatica/jdbc/JdbcResultSet.java
@@ -43,10 +43,16 @@ class JdbcResultSet extends Meta.MetaResultSet {
   /** Creates a result set. */
   public static JdbcResultSet create(String connectionId, int statementId,
       ResultSet resultSet) {
+    return create(connectionId, statementId, resultSet, -1);
+  }
+
+  /** Creates a result set with maxRowCount. */
+  public static JdbcResultSet create(String connectionId, int statementId,
+      ResultSet resultSet, int maxRowCount) {
     try {
       Meta.Signature sig = JdbcMeta.signature(resultSet.getMetaData());
       final Calendar calendar = Calendar.getInstance(DateTimeUtils.GMT_ZONE);
-      final Meta.Frame firstFrame = frame(resultSet, 0, -1, calendar);
+      final Meta.Frame firstFrame = frame(resultSet, 0, maxRowCount, calendar);
       resultSet.close();
       return new JdbcResultSet(connectionId, statementId, true, sig,
           firstFrame);

--- a/avatica-server/src/test/java/org/apache/calcite/avatica/RemoteDriverTest.java
+++ b/avatica-server/src/test/java/org/apache/calcite/avatica/RemoteDriverTest.java
@@ -266,11 +266,25 @@ public class RemoteDriverTest {
     checkStatementExecute(ljs(), false);
   }
 
+  @Test public void testStatementExecuteLocalMaxRow() throws Exception {
+    checkStatementExecute(ljs(), false, 2);
+  }
+
+  @Ignore("CALCITE-719: Refactor PreparedStatement to support setMaxRows")
+  @Test public void testStatementPrepareExecuteLocalMaxRow() throws Exception {
+    checkStatementExecute(ljs(), true, 2);
+  }
+
   @Test public void testPrepareExecuteLocal() throws Exception {
     checkStatementExecute(ljs(), true);
   }
 
-  private void checkStatementExecute(Connection connection, boolean prepare) throws SQLException {
+  private void checkStatementExecute(Connection connection,
+      boolean prepare) throws SQLException {
+    checkStatementExecute(connection, prepare, 0);
+  }
+  private void checkStatementExecute(Connection connection,
+      boolean prepare, int maxRowCount) throws SQLException {
     final String sql = "select * from (\n"
         + "  values (1, 'a'), (null, 'b'), (3, 'c')) as t (c1, c2)";
     final Statement statement;
@@ -279,11 +293,13 @@ public class RemoteDriverTest {
     if (prepare) {
       final PreparedStatement ps = connection.prepareStatement(sql);
       statement = ps;
+      ps.setMaxRows(maxRowCount);
       parameterMetaData = ps.getParameterMetaData();
       assertTrue(ps.execute());
       resultSet = ps.getResultSet();
     } else {
       statement = connection.createStatement();
+      statement.setMaxRows(maxRowCount);
       parameterMetaData = null;
       assertTrue(statement.execute(sql));
       resultSet = statement.getResultSet();
@@ -295,9 +311,9 @@ public class RemoteDriverTest {
     assertEquals(2, metaData.getColumnCount());
     assertEquals("C1", metaData.getColumnName(1));
     assertEquals("C2", metaData.getColumnName(2));
-    assertTrue(resultSet.next());
-    assertTrue(resultSet.next());
-    assertTrue(resultSet.next());
+    for (int i = 0; i < maxRowCount || (maxRowCount == 0 && i < 3); i++) {
+      assertTrue(resultSet.next());
+    }
     assertFalse(resultSet.next());
     resultSet.close();
     statement.close();

--- a/avatica-server/src/test/java/org/apache/calcite/avatica/RemoteDriverTest.java
+++ b/avatica-server/src/test/java/org/apache/calcite/avatica/RemoteDriverTest.java
@@ -268,6 +268,47 @@ public class RemoteDriverTest {
     checkStatementExecute(ljs(), false);
   }
 
+  @Test public void testStatementExecuteFetch() throws Exception {
+    // Creating a > 100 rows queries to enable fetch request
+    String sql = "select * from emp cross join emp";
+    checkExecuteFetch(ljs(), sql, false, 1);
+    // PreparedStatement needed an extra fetch, as the execute will
+    // trigger the 1st fetch. Where statement execute will execute direct
+    // with results back.
+    checkExecuteFetch(ljs(), sql, true, 2);
+  }
+
+  private void checkExecuteFetch(Connection conn, String sql, boolean isPrepare,
+    int fetchCountMatch) throws SQLException {
+    final Statement exeStatement;
+    final ResultSet results;
+    LoggingLocalJsonService.THREAD_LOG.get().enableAndClear();
+    if (isPrepare) {
+      PreparedStatement statement = conn.prepareStatement(sql);
+      exeStatement = statement;
+      results = statement.executeQuery();
+    } else {
+      Statement statement = conn.createStatement();
+      exeStatement = statement;
+      results = statement.executeQuery(sql);
+    }
+    int count = 0;
+    int fetchCount = 0;
+    while (results.next()) {
+      count++;
+    }
+    results.close();
+    exeStatement.close();
+    List<String[]> x = LoggingLocalJsonService.THREAD_LOG.get().getAndDisable();
+    for (String[] pair : x) {
+      if (pair[0].contains("\"request\":\"fetch")) {
+        fetchCount++;
+      }
+    }
+    assertEquals(count, 196);
+    assertEquals(fetchCount, fetchCountMatch);
+  }
+
   @Test public void testStatementExecuteLocalMaxRow() throws Exception {
     checkStatementExecute(ljs(), false, 2);
   }
@@ -586,15 +627,16 @@ public class RemoteDriverTest {
   }
 
   @Test public void testPrepareBindExecuteFetch() throws Exception {
-    if (JDK17) {
-      return;
-    }
+//    if (JDK17) {
+//      return;
+//    }
     LoggingLocalJsonService.THREAD_LOG.get().enableAndClear();
     checkPrepareBindExecuteFetch(ljs());
     List<String[]> x = LoggingLocalJsonService.THREAD_LOG.get().getAndDisable();
     for (String[] pair : x) {
       System.out.println(pair[0] + "=" + pair[1]);
     }
+
   }
 
   private void checkPrepareBindExecuteFetch(Connection connection)

--- a/avatica-server/src/test/java/org/apache/calcite/avatica/RemoteDriverTest.java
+++ b/avatica-server/src/test/java/org/apache/calcite/avatica/RemoteDriverTest.java
@@ -43,7 +43,9 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
@@ -587,7 +589,12 @@ public class RemoteDriverTest {
     if (JDK17) {
       return;
     }
+    LoggingLocalJsonService.THREAD_LOG.get().enableAndClear();
     checkPrepareBindExecuteFetch(ljs());
+    List<String[]> x = LoggingLocalJsonService.THREAD_LOG.get().getAndDisable();
+    for (String[] pair : x) {
+      System.out.println(pair[0] + "=" + pair[1]);
+    }
   }
 
   private void checkPrepareBindExecuteFetch(Connection connection)
@@ -780,7 +787,7 @@ public class RemoteDriverTest {
         final JdbcMeta jdbcMeta = new JdbcMeta(CONNECTION_SPEC.url,
             CONNECTION_SPEC.username, CONNECTION_SPEC.password);
         final LocalService localService = new LocalService(jdbcMeta);
-        service = new LocalJsonService(localService);
+        service = new LoggingLocalJsonService(localService);
       } catch (SQLException e) {
         throw new RuntimeException(e);
       }
@@ -843,6 +850,63 @@ public class RemoteDriverTest {
       jdbcMetaConnectionCacheF.setAccessible(true);
       //noinspection unchecked
       return (Cache<String, Connection>) jdbcMetaConnectionCacheF.get(serverMeta);
+    }
+  }
+
+  /** Extension to {@link LocalJsonService} that writes requests and responses
+   * into a thread-local. */
+  private static class LoggingLocalJsonService extends LocalJsonService {
+    private static final ThreadLocal<RequestLogger> THREAD_LOG =
+        new ThreadLocal<RequestLogger>() {
+          @Override
+          protected RequestLogger initialValue() {
+            return new RequestLogger();
+          }
+        };
+
+    public LoggingLocalJsonService(LocalService localService) {
+      super(localService);
+    }
+
+    @Override
+    public String apply(String request) {
+      final RequestLogger logger = THREAD_LOG.get();
+      logger.requestStart(request);
+      final String response = super.apply(request);
+      logger.requestEnd(request, response);
+      return response;
+    }
+  }
+
+  /** Logs request and response strings if enabled. */
+  private static class RequestLogger {
+    final List<String[]> requestResponses = new ArrayList<>();
+    boolean enabled;
+
+    void enableAndClear() {
+      enabled = true;
+      requestResponses.clear();
+    }
+
+    void requestStart(String request) {
+      if (enabled) {
+        requestResponses.add(new String[]{request, null});
+      }
+    }
+
+    void requestEnd(String request, String response) {
+      if (enabled) {
+        String[] last = requestResponses.get(requestResponses.size() - 1);
+        if (!request.equals(last[0])) {
+          throw new AssertionError();
+        }
+        last[1] = response;
+      }
+    }
+
+    List<String[]> getAndDisable() {
+      enabled = false;
+      return new ArrayList<>(requestResponses);
     }
   }
 

--- a/avatica/src/main/java/org/apache/calcite/avatica/AvaticaConnection.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/AvaticaConnection.java
@@ -474,7 +474,7 @@ public abstract class AvaticaConnection implements Connection {
             }
           }
         };
-    return meta.prepareAndExecute(handle, sql, maxRowCount, callback);
+    return meta.prepareAndExecute(statement.handle, sql, maxRowCount, callback);
   }
 
   protected ResultSet createResultSet(Meta.MetaResultSet metaResultSet)

--- a/avatica/src/main/java/org/apache/calcite/avatica/AvaticaPreparedStatement.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/AvaticaPreparedStatement.java
@@ -48,7 +48,7 @@ import java.util.List;
 public abstract class AvaticaPreparedStatement
     extends AvaticaStatement
     implements PreparedStatement, ParameterMetaData {
-  private final Meta.Signature signature;
+  private Meta.Signature signature;
   private final ResultSetMetaData resultSetMetaData;
   private Calendar calendar;
   protected final TypedValue[] slots;

--- a/avatica/src/main/java/org/apache/calcite/avatica/AvaticaStatement.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/AvaticaStatement.java
@@ -36,7 +36,7 @@ public abstract class AvaticaStatement
     implements Statement {
   public final AvaticaConnection connection;
   /** Statement id; unique within connection. */
-  public final Meta.StatementHandle handle;
+  public Meta.StatementHandle handle;
   protected boolean closed;
 
   /**

--- a/avatica/src/main/java/org/apache/calcite/avatica/Meta.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/Meta.java
@@ -176,7 +176,7 @@ public interface Meta {
    * @return Result containing statement ID, and if a query, a result set and
    * first frame of data
    */
-  ExecuteResult prepareAndExecute(ConnectionHandle ch, String sql,
+  ExecuteResult prepareAndExecute(StatementHandle statementHandle, String sql,
       int maxRowCount, PrepareCallback callback);
 
   /** Returns a frame of rows.

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/LocalService.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/LocalService.java
@@ -67,7 +67,6 @@ public class LocalService implements Service {
       }
     } else {
       //noinspection unchecked
-      list = (List<Object>) (List) list2(resultSet);
       cursorFactory = Meta.CursorFactory.LIST;
     }
     Meta.Signature signature = resultSet.signature;
@@ -75,7 +74,7 @@ public class LocalService implements Service {
       signature = signature.setCursorFactory(cursorFactory);
     }
     return new ResultSetResponse(resultSet.connectionId, resultSet.statementId,
-        resultSet.ownStatement, signature, new Meta.Frame(0, true, list), -1);
+        resultSet.ownStatement, signature, resultSet.firstFrame, -1);
   }
 
   private List<List<Object>> list2(Meta.MetaResultSet resultSet) {
@@ -131,10 +130,10 @@ public class LocalService implements Service {
   }
 
   public ExecuteResponse apply(PrepareAndExecuteRequest request) {
-    final Meta.ConnectionHandle ch =
-        new Meta.ConnectionHandle(request.connectionId);
+    final Meta.StatementHandle sh =
+        new Meta.StatementHandle(request.connectionId, request.statementId, null);
     final Meta.ExecuteResult executeResult =
-        meta.prepareAndExecute(ch, request.sql, request.maxRowCount,
+        meta.prepareAndExecute(sh, request.sql, request.maxRowCount,
             new Meta.PrepareCallback() {
               @Override public Object getMonitor() {
                 return LocalService.class;

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/RemoteMeta.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/RemoteMeta.java
@@ -159,15 +159,18 @@ class RemoteMeta extends MetaImpl {
     return response.statement;
   }
 
-  @Override public ExecuteResult prepareAndExecute(ConnectionHandle ch,
+  @Override public ExecuteResult prepareAndExecute(StatementHandle statementHandle,
       String sql, int maxRowCount, PrepareCallback callback) {
-    connectionSync(ch, new ConnectionPropertiesImpl()); // sync connection state if necessary
+    // sync connection state if necessary
+    connectionSync(new ConnectionHandle(statementHandle.connectionId),
+      new ConnectionPropertiesImpl());
     final Service.ExecuteResponse response;
     try {
       synchronized (callback.getMonitor()) {
         callback.clear();
         response = service.apply(
-            new Service.PrepareAndExecuteRequest(ch.id, sql, maxRowCount));
+            new Service.PrepareAndExecuteRequest(statementHandle.connectionId,
+              statementHandle.id, sql, maxRowCount));
         if (response.results.size() > 0) {
           final Service.ResultSetResponse result = response.results.get(0);
           callback.assign(result.signature, result.firstFrame,

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/Service.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/Service.java
@@ -237,13 +237,16 @@ public interface Service {
     public final String connectionId;
     public final String sql;
     public final int maxRowCount;
+    public final int statementId;
 
     @JsonCreator
     public PrepareAndExecuteRequest(
         @JsonProperty("connectionId") String connectionId,
+        @JsonProperty("statementId") int statementId,
         @JsonProperty("sql") String sql,
         @JsonProperty("maxRowCount") int maxRowCount) {
       this.connectionId = connectionId;
+      this.statementId = statementId;
       this.sql = sql;
       this.maxRowCount = maxRowCount;
     }

--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteMetaImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteMetaImpl.java
@@ -492,24 +492,24 @@ public class CalciteMetaImpl extends MetaImpl {
     return h;
   }
 
-  @Override public ExecuteResult prepareAndExecute(ConnectionHandle ch,
+  @Override public ExecuteResult prepareAndExecute(StatementHandle statementHandle,
       String sql, int maxRowCount, PrepareCallback callback) {
     final CalcitePrepare.CalciteSignature<Object> signature;
-    final StatementHandle h = createStatement(ch);
-
     try {
       synchronized (callback.getMonitor()) {
         callback.clear();
         final CalciteConnectionImpl calciteConnection = getConnection();
         CalciteServerStatement statement =
-            calciteConnection.server.getStatement(h);
+            calciteConnection.server.getStatement(statementHandle);
         signature = calciteConnection.parseQuery(sql,
             statement.createPrepareContext(), maxRowCount);
+        statement.setSignature(signature);
         callback.assign(signature, null, -1);
       }
       callback.execute();
       final MetaResultSet metaResultSet =
-          MetaResultSet.create(h.connectionId, h.id, false, signature, null);
+          MetaResultSet.create(statementHandle.connectionId,
+            statementHandle.id, false, signature, null);
       return new ExecuteResult(ImmutableList.of(metaResultSet));
     } catch (SQLException e) {
       throw new RuntimeException(e);

--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteMetaImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteMetaImpl.java
@@ -483,6 +483,7 @@ public class CalciteMetaImpl extends MetaImpl {
       int maxRowCount) {
     final StatementHandle h = createStatement(ch);
     final CalciteConnectionImpl calciteConnection = getConnection();
+
     CalciteServerStatement statement = calciteConnection.server.getStatement(h);
     h.signature =
         calciteConnection.parseQuery(sql, statement.createPrepareContext(),
@@ -495,6 +496,7 @@ public class CalciteMetaImpl extends MetaImpl {
       String sql, int maxRowCount, PrepareCallback callback) {
     final CalcitePrepare.CalciteSignature<Object> signature;
     final StatementHandle h = createStatement(ch);
+
     try {
       synchronized (callback.getMonitor()) {
         callback.clear();

--- a/core/src/test/java/org/apache/calcite/jdbc/CalciteRemoteDriverTest.java
+++ b/core/src/test/java/org/apache/calcite/jdbc/CalciteRemoteDriverTest.java
@@ -453,6 +453,18 @@ public class CalciteRemoteDriverTest {
     assertTrue(count > 0);
   }
 
+  @Test public void testRemoteExecuteMaxRow() throws Exception {
+    Statement statement = remoteConnection.createStatement();
+    statement.setMaxRows(2);
+    ResultSet resultSet = statement.executeQuery(
+            "select * from \"hr\".\"emps\"");
+    int count = 0;
+    while (resultSet.next()) {
+      ++count;
+    }
+    assertThat(count, equalTo(2));
+  }
+
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-661">[CALCITE-661]
    * Remote fetch in Calcite JDBC driver</a>. */


### PR DESCRIPTION
[CALCITE-718] Enable fetch to work for Statement.execute() for Avatica
[CALCITE-712]-Fix setMaxRows for statement execute, returning maximum row specified.

Merge with 712 setMaxRows.