### PR TITLE
[CALCITE-765] Set Content-Type from the RPC server to application/json

### DIFF
--- a/avatica-server/src/main/java/org/apache/calcite/avatica/server/AvaticaHandler.java
+++ b/avatica-server/src/main/java/org/apache/calcite/avatica/server/AvaticaHandler.java
@@ -45,7 +45,7 @@ public class AvaticaHandler extends AbstractHandler {
   public void handle(String target, Request baseRequest,
       HttpServletRequest request, HttpServletResponse response)
       throws IOException, ServletException {
-    response.setContentType("text/html;charset=utf-8");
+    response.setContentType("application/json;charset=utf-8");
     response.setStatus(HttpServletResponse.SC_OK);
     if (request.getMethod().equals("POST")) {
       final String jsonRequest =


### PR DESCRIPTION
Trivial patch for https://issues.apache.org/jira/browse/CALCITE-765