### PR TITLE
CALCITE-761 Pre-populated materializations

### DIFF
--- a/core/src/main/java/org/apache/calcite/materialize/MaterializationService.java
+++ b/core/src/main/java/org/apache/calcite/materialize/MaterializationService.java
@@ -116,7 +116,10 @@ public class MaterializationService {
 
     final CalciteConnection connection =
         CalciteMetaImpl.connect(schema.root(), null);
-    CalciteSchema.TableEntry tableEntry = schema.getTableBySql(viewSql);
+    CalciteSchema.TableEntry tableEntry = schema.getTable(suggestedTableName, true);
+    if (tableEntry == null) {
+      tableEntry = schema.getTableBySql(viewSql);
+    }
     RelDataType rowType = null;
     if (tableEntry == null) {
       Table table = tableFactory.createTable(schema, viewSql, viewSchemaPath);


### PR DESCRIPTION
This already solves the other problem I mentioned earlier: since the create table logic won't be called for pre-populated materialized view here, the connection does not have to know any rules for a specific convention.

However, there is another requirement in Phoenix that the index table exists under the same schema with its parent (data) table. So this means the "suggestedTableName" might have to have both the sub-schema name and the table name. Or is any other way to do this?