### PR TITLE
[CALCITE-786] Enhancing detection of MV to rewrite queries.

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/MaterializedViewSubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/MaterializedViewSubstitutionVisitor.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package plan;
+
+import org.apache.calcite.plan.SubstitutionVisitor;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+/**
+ * Substitutes part of a tree of relational expressions with another tree.
+ *
+ * <p>The call {@code new SubstitutionVisitor(target, query).go(replacement))}
+ * will return {@code query} with every occurrence of {@code target} replaced
+ * by {@code replacement}.</p>
+ *
+ * <p>The following example shows how {@code SubstitutionVisitor} can be used
+ * for materialized view recognition.</p>
+ *
+ * <ul>
+ * <li>query = SELECT a, c FROM t WHERE x = 5 AND b = 4</li>
+ * <li>target = SELECT a, b, c FROM t WHERE x = 5</li>
+ * <li>replacement = SELECT * FROM mv</li>
+ * <li>result = SELECT a, c FROM mv WHERE b = 4</li>
+ * </ul>
+ *
+ * <p>Note that {@code result} uses the materialized view table {@code mv} and a
+ * simplified condition {@code b = 4}.</p>
+ *
+ * <p>Uses a bottom-up matching algorithm. Nodes do not need to be identical.
+ * At each level, returns the residue.</p>
+ *
+ * <p>The inputs must only include the core relational operators:
+ * {@link org.apache.calcite.rel.logical.LogicalTableScan},
+ * {@link LogicalFilter},
+ * {@link LogicalProject},
+ * {@link org.apache.calcite.rel.logical.LogicalJoin},
+ * {@link LogicalUnion},
+ * {@link LogicalAggregate}.</p>
+ */
+public class MaterializedViewSubstitutionVisitor extends SubstitutionVisitor {
+
+  public MaterializedViewSubstitutionVisitor(RelNode target_, RelNode query_) {
+    super(target_, query_);
+    this.unifyRules = ImmutableList.<UnifyRule>of(ProjectToProjectUnifyRule1.INSTANCE);
+  }
+
+  public RelNode go(RelNode replacement_) {
+    this.RULE_MAP.clear();
+    return super.go(replacement_);
+  }
+
+  /**
+   * Project to Project Unify rule.
+   */
+
+  private static class ProjectToProjectUnifyRule1 extends AbstractUnifyRule {
+    public static final ProjectToProjectUnifyRule1 INSTANCE =
+            new ProjectToProjectUnifyRule1();
+
+    private ProjectToProjectUnifyRule1() {
+      super(operand(MutableProject.class, query(0)),
+              operand(MutableProject.class, target(0)), 1);
+    }
+
+    @Override
+    protected UnifyResult apply(UnifyRuleCall call) {
+      final MutableProject target = (MutableProject) call.target;
+      final MutableProject query = (MutableProject) call.query;
+      final RexShuttle shuttle = getRexShuttle(target);
+      final List<RexNode> newProjects;
+      try {
+        newProjects = shuttle.apply(query.getProjects());
+      } catch (MatchFailed e) {
+        return null;
+      }
+      final MutableProject newProject =
+              MutableProject.of(
+                      query.getRowType(), target, newProjects);
+      final MutableRel newProject2 = MutableRels.strip(newProject);
+      return call.result(newProject2);
+    }
+
+    @Override
+    protected UnifyRuleCall match(SubstitutionVisitor visitor, MutableRel query,
+                        MutableRel target) {
+      if (queryOperand.matches(visitor, query)) {
+        if (targetOperand.matches(visitor, target)) {
+          return null;
+        } else if (targetOperand.isWeaker(visitor, target)) {
+
+          final MutableProject queryProject = (MutableProject) query;
+          final MutableProject queryTarget = (MutableProject) target;
+          if (queryProject.getInput() instanceof MutableFilter) {
+
+            final MutableFilter innerFilter = (MutableFilter) (queryProject.getInput());
+            final RexNode newCondition = innerFilter.getCondition();
+            final MutableFilter newFilter = MutableFilter.of(target,
+                    newCondition);
+
+            final MutableProject newTarget =
+                    MutableProject.of(queryProject.getRowType(), newFilter,
+                            queryProject.getProjects());
+
+            return visitor.new UnifyRuleCall(this, query, newTarget,
+                    copy(visitor.getSlots(), slotCount));
+          }
+        }
+      }
+      return null;
+    }
+  }
+}
+
+// End SubstitutionVisitor.java

--- a/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
@@ -1199,7 +1199,7 @@ public abstract class RelOptUtil {
         false);
   }
 
-  private static SqlKind reverse(SqlKind kind) {
+  public static SqlKind reverse(SqlKind kind) {
     switch (kind) {
     case GREATER_THAN:
       return SqlKind.LESS_THAN;
@@ -1214,7 +1214,7 @@ public abstract class RelOptUtil {
     }
   }
 
-  private static SqlOperator op(SqlKind kind, SqlOperator operator) {
+  public static SqlOperator op(SqlKind kind, SqlOperator operator) {
     switch (kind) {
     case EQUALS:
       return SqlStdOperatorTable.EQUALS;

--- a/core/src/main/java/org/apache/calcite/plan/RexImplicationChecker.java
+++ b/core/src/main/java/org/apache/calcite/plan/RexImplicationChecker.java
@@ -168,9 +168,15 @@ public class RexImplicationChecker {
     final RexExecutable exec = rexImpl.getExecutable(builder,
             constExps, rowType);
 
+    Object[] result;
     exec.setDataContext(dataValues);
-    Object[] result = exec.execute();
-
+    try {
+      result = exec.execute();
+    } catch (Exception e) {
+      // TODO: CheckSupport should not allow this exception to be thrown
+      // Need to monitor it and handle all the cases raising them.
+      return false;
+    }
     return result != null && result.length == 1 && result[0] instanceof Boolean
             && (Boolean) result[0];
   }
@@ -182,10 +188,11 @@ public class RexImplicationChecker {
    *    given set of operations only: >,<,<=,>=,=,!=
    * 2. All the variables used in second condition should be used even in the first.
    * 3. If operator used for variable in first is op1 and op2 for second, then we support
-   *    these combination for conjunction (op1, op2):
-   *    a. (</<=, </<=)
-   *    b. (>/>=, >/>=)
-   *    c. (=, >,>=,<,<=,=,!=)
+   *    these combination for conjunction (op1, op2) then op1, op2 belongs to
+   *    one of the following sets:
+   *    a. (<,<=) X (<,<=) , X represents cartesian product
+   *    b. (>/>=) X (>,>=)
+   *    c. (=) X (>,>=,<,<=,=,!=)
    *    d. (!=, =)
    * @param firstUsgFinder
    * @param secondUsgFinder

--- a/core/src/main/java/org/apache/calcite/plan/RexImplicationChecker.java
+++ b/core/src/main/java/org/apache/calcite/plan/RexImplicationChecker.java
@@ -1,0 +1,343 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package plan;
+
+import org.apache.calcite.DataContext;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.plan.VisitorDataContext;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexExecutable;
+import org.apache.calcite.rex.RexExecutorImpl;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.rex.RexVisitorImpl;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlCastFunction;
+import org.apache.calcite.util.Pair;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+
+/** Checks if Condition X logically implies Condition Y
+ *
+ * <p>(x > 10) implies (x > 5)</p>
+ *
+ * <p>(y = 10) implies (y < 30 AND x > 30)</p>
+ */
+public class RexImplicationChecker {
+  final RexBuilder builder;
+  final RexExecutorImpl rexImpl;
+  final RelDataType rowType;
+
+  public RexImplicationChecker(RexBuilder builder,
+                                RexExecutorImpl rexImpl,
+                                RelDataType rowType) {
+    this.builder = builder;
+    this.rexImpl = rexImpl;
+    this.rowType = rowType;
+  }
+
+  /**
+   * Checks if condition first implies (=>) condition second
+   * This reduces to SAT problem which is NP-Complete
+   * When func says first => second then it is definitely true
+   * It cannot prove if first doesnot imply second.
+   * @param first
+   * @param second
+   * @return true if it can prove first => second, otherwise false i.e.,
+   * it doesn't know if implication holds .
+   */
+  public boolean implies(RexNode first, RexNode second) {
+
+    // Validation
+    if (!validate(first, second)) {
+      return false;
+    }
+
+    RexCall firstCond = (RexCall) first;
+    RexCall secondCond = (RexCall) second;
+
+    // Get DNF
+    RexNode firstDnf = RexUtil.toDnf(builder, first);
+    RexNode secondDnf = RexUtil.toDnf(builder, second);
+
+    // Check Trivial Cases
+    if (firstDnf.isAlwaysFalse()
+            || secondDnf.isAlwaysTrue()) {
+      return true;
+    }
+
+    /** Decompose DNF into List of Conjunctions
+     *
+     * (x > 10 AND y > 30) OR (z > 90) will be converted to
+     * list of 2 conditions:
+     * 1. (x > 10 AND y > 30)
+     * 2. (z > 90)
+     *
+     */
+    List<RexNode> firstDnfs = RelOptUtil.disjunctions(firstDnf);
+    List<RexNode> secondDnfs = RelOptUtil.disjunctions(secondDnf);
+
+    for (RexNode f : firstDnfs) {
+      if (!f.isAlwaysFalse()) {
+        //Check if f implies atleast
+        // one of the conjunctions in list secondDnfs
+        boolean implyOneConjuntion = false;
+        for (RexNode s : secondDnfs) {
+          if (s.isAlwaysFalse()) { // f cannot imply s
+            continue;
+          }
+
+          if (impliesConjunction(f, s)) {
+            // Satisfies one of the condition, so lets
+            // move to next conjunction in firstDnfs
+            implyOneConjuntion = true;
+            break;
+          }
+        } //end of inner loop
+
+        // If f couldnot imply even one conjunction in
+        // secondDnfs, then final implication may be false
+        if (!implyOneConjuntion) {
+          return false;
+        }
+      }
+    } //end of outer loop
+
+    return true;
+  }
+
+  /** Checks if conjunction first => Conjunction second**/
+  private boolean impliesConjunction(RexNode first, RexNode second) {
+
+    InputUsageFinder firstUsgFinder = new InputUsageFinder();
+    InputUsageFinder secondUsgFinder = new InputUsageFinder();
+
+    RexUtil.apply(firstUsgFinder, new ArrayList<RexNode>(), first);
+    RexUtil.apply(secondUsgFinder, new ArrayList<RexNode>(), second);
+
+    // Check Support
+
+    if (!checkSupport(firstUsgFinder, secondUsgFinder)) {
+      return false;
+    }
+
+    List<Pair<RexInputRef, RexNode>> usgList = new ArrayList<>();
+    for (Map.Entry<RexInputRef, InputRefUsage<SqlOperator,
+            RexNode>> entry: firstUsgFinder.usageMap.entrySet()) {
+      final List<Pair<SqlOperator, RexNode>> list = entry.getValue().getUsageList();
+      usgList.add(Pair.of(entry.getKey(), list.get(0).getValue()));
+    }
+
+    final DataContext dataValues = VisitorDataContext.getDataContext(rowType, usgList);
+
+    if (dataValues == null) {
+      return false;
+    }
+
+    ImmutableList<RexNode> constExps = ImmutableList.of(second);
+    final RexExecutable exec = rexImpl.getExecutable(builder,
+            constExps, rowType);
+
+    exec.setDataContext(dataValues);
+    Object[] result = exec.execute();
+
+    return result != null && result.length == 1 && result[0] instanceof Boolean
+            && (Boolean) result[0];
+  }
+
+  private boolean checkSupport(InputUsageFinder firstUsgFinder, InputUsageFinder secondUsgFinder) {
+    Map<RexInputRef, InputRefUsage<SqlOperator,
+            RexNode>> firstUsgMap = firstUsgFinder.usageMap;
+    Map<RexInputRef, InputRefUsage<SqlOperator,
+            RexNode>> secondUsgMap = secondUsgFinder.usageMap;
+
+    for (Map.Entry<RexInputRef, InputRefUsage<SqlOperator,
+            RexNode>> entry: firstUsgMap.entrySet()) {
+      if (entry.getValue().usageCount > 1) {
+        return false;
+      }
+    }
+
+    for (Map.Entry<RexInputRef, InputRefUsage<SqlOperator,
+            RexNode>> entry: secondUsgMap.entrySet()) {
+      final InputRefUsage<SqlOperator, RexNode> secondUsage = entry.getValue();
+      if (secondUsage.usageCount > 1
+              || secondUsage.usageList.size() != 1) {
+        return false;
+      }
+
+      final InputRefUsage<SqlOperator, RexNode> firstUsage = firstUsgMap.get(entry.getKey());
+      if (firstUsage == null
+              || firstUsage.usageList.size() != 1) {
+        return false;
+      }
+
+      final Pair<SqlOperator, RexNode> fUse = firstUsage.getUsageList().get(0);
+      final Pair<SqlOperator, RexNode> sUse = secondUsage.getUsageList().get(0);
+
+      final SqlKind fkind = fUse.getKey().getKind();
+
+      switch (sUse.getKey().getKind()) {
+      case GREATER_THAN:
+      case GREATER_THAN_OR_EQUAL:
+        if (!(fkind == SqlKind.GREATER_THAN)
+                && !(fkind == SqlKind.GREATER_THAN_OR_EQUAL)) {
+          return false;
+        }
+        break;
+      case LESS_THAN:
+      case LESS_THAN_OR_EQUAL:
+        if (!(fkind == SqlKind.LESS_THAN)
+                && !(fkind == SqlKind.LESS_THAN_OR_EQUAL)) {
+          return false;
+        }
+        break;
+      default:
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean validate(RexNode first, RexNode second) {
+    if (first == null || second == null) {
+      return false;
+    }
+    if (!(first instanceof RexCall)
+            || !(second instanceof RexCall)) {
+      return false;
+    }
+    return true;
+  }
+
+
+  /**
+   * Visitor which builds a Usage Map of inputs used by an expression.
+   */
+  private static class InputUsageFinder extends RexVisitorImpl<Void> {
+    public final Map<RexInputRef, InputRefUsage<SqlOperator,
+            RexNode>> usageMap = new HashMap<>();
+
+    public InputUsageFinder() {
+      super(true);
+    }
+
+    public Void visitInputRef(RexInputRef inputRef) {
+      InputRefUsage<SqlOperator,
+              RexNode> inputRefUse = getUsageMap(inputRef);
+      inputRefUse.incrUsage();
+      return null;
+    }
+
+    @Override public Void visitCall(RexCall call) {
+      switch (call.getOperator().getKind()) {
+      case GREATER_THAN:
+      case GREATER_THAN_OR_EQUAL:
+      case LESS_THAN:
+      case LESS_THAN_OR_EQUAL:
+      case EQUALS:
+        updateUsage(call);
+        break;
+      default:
+      }
+      return super.visitCall(call);
+    }
+
+    private void updateUsage(RexCall call) {
+      final List<RexNode> operands = call.getOperands();
+      RexNode first = removeCast(operands.get(0));
+      RexNode second = removeCast(operands.get(1));
+
+      if (first.isA(SqlKind.INPUT_REF)
+              && second.isA(SqlKind.LITERAL)) {
+        updateUsage(call.getOperator(), (RexInputRef) first, second);
+      }
+
+      if (first.isA(SqlKind.LITERAL)
+              && second.isA(SqlKind.INPUT_REF)) {
+        updateUsage(call.getOperator(), (RexInputRef) second, first);
+      }
+    }
+
+    private static RexNode removeCast(RexNode inputRef) {
+      if (inputRef instanceof RexCall) {
+        final RexCall castedRef = (RexCall) inputRef;
+        final SqlOperator operator = castedRef.getOperator();
+        if (operator instanceof SqlCastFunction) {
+          inputRef = castedRef.getOperands().get(0);
+        }
+      }
+      return inputRef;
+    }
+
+    private void updateUsage(SqlOperator op, RexInputRef inputRef, RexNode literal) {
+      InputRefUsage<SqlOperator,
+              RexNode> inputRefUse = getUsageMap(inputRef);
+      Pair<SqlOperator, RexNode> use = Pair.of(op, literal);
+      inputRefUse.getUsageList().add(use);
+    }
+
+    private InputRefUsage<SqlOperator, RexNode> getUsageMap(RexInputRef rex) {
+      InputRefUsage<SqlOperator, RexNode> inputRefUse = usageMap.get(rex);
+      if (inputRefUse == null) {
+        inputRefUse = new InputRefUsage<>();
+        usageMap.put(rex, inputRefUse);
+      }
+
+      return inputRefUse;
+    }
+  }
+
+  /**
+   * DataStructure to store usage of InputRefs in expression
+   * @param <T1>
+   * @param <T2>
+   */
+
+  private static class InputRefUsage<T1, T2> {
+    final List<Pair<T1, T2>> usageList =
+            new ArrayList<Pair<T1, T2>>();
+    int usageCount = 0;
+
+    public InputRefUsage() {}
+
+    public int getUsageCount() {
+      return usageCount;
+    }
+
+    public void incrUsage() {
+      usageCount++;
+    }
+
+
+    public List<Pair<T1, T2>> getUsageList() {
+      return usageList;
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/plan/RexImplicationChecker.java
+++ b/core/src/main/java/org/apache/calcite/plan/RexImplicationChecker.java
@@ -203,6 +203,10 @@ public class RexImplicationChecker {
 
       final SqlKind fkind = fUse.getKey().getKind();
 
+      if (fkind == SqlKind.EQUALS) {
+        return true;
+      }
+
       switch (sUse.getKey().getKind()) {
       case GREATER_THAN:
       case GREATER_THAN_OR_EQUAL:
@@ -218,15 +222,6 @@ public class RexImplicationChecker {
           return false;
         }
         break;
-      case EQUALS:
-        if (!(fkind == SqlKind.EQUALS)) {
-          return false;
-        }
-        break;
-      case NOT_EQUALS:
-        if (!(fkind == SqlKind.EQUALS)) {
-          return false;
-        }
       default:
         return false;
       }

--- a/core/src/main/java/org/apache/calcite/plan/RexImplicationChecker.java
+++ b/core/src/main/java/org/apache/calcite/plan/RexImplicationChecker.java
@@ -224,7 +224,7 @@ public class RexImplicationChecker {
         }
         break;
       case NOT_EQUALS:
-        if (! (fkind == SqlKind.EQUALS )) {
+        if (!(fkind == SqlKind.EQUALS)) {
           return false;
         }
       default:

--- a/core/src/main/java/org/apache/calcite/plan/RexImplicationChecker.java
+++ b/core/src/main/java/org/apache/calcite/plan/RexImplicationChecker.java
@@ -15,11 +15,9 @@
  * limitations under the License.
  */
 
-package plan;
+package org.apache.calcite.plan;
 
 import org.apache.calcite.DataContext;
-import org.apache.calcite.plan.RelOptUtil;
-import org.apache.calcite.plan.VisitorDataContext;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
@@ -54,9 +52,10 @@ public class RexImplicationChecker {
   final RexExecutorImpl rexImpl;
   final RelDataType rowType;
 
-  public RexImplicationChecker(RexBuilder builder,
-                                RexExecutorImpl rexImpl,
-                                RelDataType rowType) {
+  public RexImplicationChecker(
+      RexBuilder builder,
+      RexExecutorImpl rexImpl,
+      RelDataType rowType) {
     this.builder = builder;
     this.rexImpl = rexImpl;
     this.rowType = rowType;
@@ -67,8 +66,8 @@ public class RexImplicationChecker {
    * This reduces to SAT problem which is NP-Complete
    * When func says first => second then it is definitely true
    * It cannot prove if first doesnot imply second.
-   * @param first
-   * @param second
+   * @param first first condition
+   * @param second second condition
    * @return true if it can prove first => second, otherwise false i.e.,
    * it doesn't know if implication holds .
    */
@@ -88,7 +87,7 @@ public class RexImplicationChecker {
 
     // Check Trivial Cases
     if (firstDnf.isAlwaysFalse()
-            || secondDnf.isAlwaysTrue()) {
+        || secondDnf.isAlwaysTrue()) {
       return true;
     }
 
@@ -148,7 +147,7 @@ public class RexImplicationChecker {
 
     List<Pair<RexInputRef, RexNode>> usgList = new ArrayList<>();
     for (Map.Entry<RexInputRef, InputRefUsage<SqlOperator,
-            RexNode>> entry: firstUsgFinder.usageMap.entrySet()) {
+        RexNode>> entry: firstUsgFinder.usageMap.entrySet()) {
       final List<Pair<SqlOperator, RexNode>> list = entry.getValue().getUsageList();
       usgList.add(Pair.of(entry.getKey(), list.get(0).getValue()));
     }
@@ -166,7 +165,7 @@ public class RexImplicationChecker {
 
     ImmutableList<RexNode> constExps = ImmutableList.of(second);
     final RexExecutable exec = rexImpl.getExecutable(builder,
-            constExps, rowType);
+        constExps, rowType);
 
     Object[] result;
     exec.setDataContext(dataValues);
@@ -178,7 +177,7 @@ public class RexImplicationChecker {
       return false;
     }
     return result != null && result.length == 1 && result[0] instanceof Boolean
-            && (Boolean) result[0];
+        && (Boolean) result[0];
   }
 
   /**
@@ -194,34 +193,34 @@ public class RexImplicationChecker {
    *    b. (>/>=) X (>,>=)
    *    c. (=) X (>,>=,<,<=,=,!=)
    *    d. (!=, =)
-   * @param firstUsgFinder
-   * @param secondUsgFinder
-   * @return
+   * @return true, if input usage pattern is supported. Otherwise, false.
    */
-  private boolean checkSupport(InputUsageFinder firstUsgFinder, InputUsageFinder secondUsgFinder) {
+  private boolean checkSupport(
+      InputUsageFinder firstUsgFinder,
+      InputUsageFinder secondUsgFinder) {
     Map<RexInputRef, InputRefUsage<SqlOperator,
-            RexNode>> firstUsgMap = firstUsgFinder.usageMap;
+        RexNode>> firstUsgMap = firstUsgFinder.usageMap;
     Map<RexInputRef, InputRefUsage<SqlOperator,
-            RexNode>> secondUsgMap = secondUsgFinder.usageMap;
+        RexNode>> secondUsgMap = secondUsgFinder.usageMap;
 
     for (Map.Entry<RexInputRef, InputRefUsage<SqlOperator,
-            RexNode>> entry: firstUsgMap.entrySet()) {
+        RexNode>> entry: firstUsgMap.entrySet()) {
       if (entry.getValue().usageCount > 1) {
         return false;
       }
     }
 
     for (Map.Entry<RexInputRef, InputRefUsage<SqlOperator,
-            RexNode>> entry: secondUsgMap.entrySet()) {
+        RexNode>> entry: secondUsgMap.entrySet()) {
       final InputRefUsage<SqlOperator, RexNode> secondUsage = entry.getValue();
       if (secondUsage.getUsageCount() > 1
-              || secondUsage.getUsageList().size() != 1) {
+          || secondUsage.getUsageList().size() != 1) {
         return false;
       }
 
       final InputRefUsage<SqlOperator, RexNode> firstUsage = firstUsgMap.get(entry.getKey());
       if (firstUsage == null
-              || firstUsage.getUsageList().size() != 1) {
+          || firstUsage.getUsageList().size() != 1) {
         return false;
       }
 
@@ -235,14 +234,14 @@ public class RexImplicationChecker {
         case GREATER_THAN:
         case GREATER_THAN_OR_EQUAL:
           if (!(fkind == SqlKind.GREATER_THAN)
-                    && !(fkind == SqlKind.GREATER_THAN_OR_EQUAL)) {
+              && !(fkind == SqlKind.GREATER_THAN_OR_EQUAL)) {
             return false;
           }
           break;
         case LESS_THAN:
         case LESS_THAN_OR_EQUAL:
           if (!(fkind == SqlKind.LESS_THAN)
-                    && !(fkind == SqlKind.LESS_THAN_OR_EQUAL)) {
+              && !(fkind == SqlKind.LESS_THAN_OR_EQUAL)) {
             return false;
           }
           break;
@@ -259,7 +258,7 @@ public class RexImplicationChecker {
       return false;
     }
     if (!(first instanceof RexCall)
-            || !(second instanceof RexCall)) {
+        || !(second instanceof RexCall)) {
       return false;
     }
     return true;
@@ -274,7 +273,7 @@ public class RexImplicationChecker {
    */
   private static class InputUsageFinder extends RexVisitorImpl<Void> {
     public final Map<RexInputRef, InputRefUsage<SqlOperator,
-            RexNode>> usageMap = new HashMap<>();
+        RexNode>> usageMap = new HashMap<>();
 
     public InputUsageFinder() {
       super(true);
@@ -282,7 +281,7 @@ public class RexImplicationChecker {
 
     public Void visitInputRef(RexInputRef inputRef) {
       InputRefUsage<SqlOperator,
-              RexNode> inputRefUse = getUsageMap(inputRef);
+          RexNode> inputRefUse = getUsageMap(inputRef);
       inputRefUse.incrUsage();
       return null;
     }
@@ -308,19 +307,19 @@ public class RexImplicationChecker {
       RexNode second = removeCast(operands.get(1));
 
       if (first.isA(SqlKind.INPUT_REF)
-              && second.isA(SqlKind.LITERAL)) {
+          && second.isA(SqlKind.LITERAL)) {
         updateUsage(call.getOperator(), (RexInputRef) first, second);
       }
 
       if (first.isA(SqlKind.LITERAL)
-              && second.isA(SqlKind.INPUT_REF)) {
+          && second.isA(SqlKind.INPUT_REF)) {
         updateUsage(reverse(call.getOperator()), (RexInputRef) second, first);
       }
     }
 
     private SqlOperator reverse(SqlOperator op) {
       return RelOptUtil.op(
-              RelOptUtil.reverse(op.getKind()), op);
+          RelOptUtil.reverse(op.getKind()), op);
     }
 
     private static RexNode removeCast(RexNode inputRef) {
@@ -336,7 +335,7 @@ public class RexImplicationChecker {
 
     private void updateUsage(SqlOperator op, RexInputRef inputRef, RexNode literal) {
       InputRefUsage<SqlOperator,
-              RexNode> inputRefUse = getUsageMap(inputRef);
+          RexNode> inputRefUse = getUsageMap(inputRef);
       Pair<SqlOperator, RexNode> use = Pair.of(op, literal);
       inputRefUse.getUsageList().add(use);
     }
@@ -354,13 +353,11 @@ public class RexImplicationChecker {
 
   /**
    * DataStructure to store usage of InputRefs in expression
-   * @param <T1>
-   * @param <T2>
    */
 
   private static class InputRefUsage<T1, T2> {
     private final List<Pair<T1, T2>> usageList =
-            new ArrayList<Pair<T1, T2>>();
+        new ArrayList<Pair<T1, T2>>();
     private int usageCount = 0;
 
     public InputRefUsage() {}

--- a/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
@@ -144,17 +144,9 @@ public class SubstitutionVisitor {
   private static final Equivalence<List<?>> PAIRWISE_STRING_EQUIVALENCE =
       (Equivalence) STRING_EQUIVALENCE.pairwise();
 
-  protected static List<UnifyRule> unifyRules =
-      ImmutableList.<UnifyRule>of(
-//          TrivialRule.INSTANCE,
-          ProjectToProjectUnifyRule.INSTANCE,
-          FilterToProjectUnifyRule.INSTANCE,
-//          ProjectToFilterUnifyRule.INSTANCE,
-          FilterToFilterUnifyRule.INSTANCE,
-          AggregateToAggregateUnifyRule.INSTANCE,
-          AggregateOnProjectToAggregateUnifyRule.INSTANCE);
+  protected static List<UnifyRule> unifyRules;
 
-  private static final Map<Pair<Class, Class>, List<UnifyRule>> RULE_MAP =
+  protected static final Map<Pair<Class, Class>, List<UnifyRule>> RULE_MAP =
       new HashMap<>();
 
   private final RelOptCluster cluster;
@@ -208,6 +200,24 @@ public class SubstitutionVisitor {
     visitor.go(query);
     allNodes.removeAll(parents);
     queryLeaves = ImmutableList.copyOf(allNodes);
+    initUnifyRules();
+    initRuleMap();
+  }
+
+  public void initUnifyRules() {
+    unifyRules =
+            ImmutableList.<UnifyRule>of(
+//          TrivialRule.INSTANCE,
+                    ProjectToProjectUnifyRule.INSTANCE,
+                    FilterToProjectUnifyRule.INSTANCE,
+//          ProjectToFilterUnifyRule.INSTANCE,
+                    FilterToFilterUnifyRule.INSTANCE,
+                    AggregateToAggregateUnifyRule.INSTANCE,
+                    AggregateOnProjectToAggregateUnifyRule.INSTANCE);
+  }
+
+  public void initRuleMap() {
+    this.RULE_MAP.clear();
   }
 
   public MutableRel[] getSlots() {
@@ -1195,7 +1205,7 @@ public class SubstitutionVisitor {
 
   /** Builds a shuttle that stores a list of expressions, and can map incoming
    * expressions to references to them. */
-  private static RexShuttle getRexShuttle(MutableProject target) {
+  protected static RexShuttle getRexShuttle(MutableProject target) {
     final Map<String, Integer> map = new HashMap<>();
     for (RexNode e : target.getProjects()) {
       map.put(e.toString(), map.size());

--- a/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
@@ -41,6 +41,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexExecutorImpl;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
@@ -143,7 +144,7 @@ public class SubstitutionVisitor {
   private static final Equivalence<List<?>> PAIRWISE_STRING_EQUIVALENCE =
       (Equivalence) STRING_EQUIVALENCE.pairwise();
 
-  private static final List<UnifyRule> RULES =
+  protected static List<UnifyRule> unifyRules =
       ImmutableList.<UnifyRule>of(
 //          TrivialRule.INSTANCE,
           ProjectToProjectUnifyRule.INSTANCE,
@@ -207,6 +208,10 @@ public class SubstitutionVisitor {
     visitor.go(query);
     allNodes.removeAll(parents);
     queryLeaves = ImmutableList.copyOf(allNodes);
+  }
+
+  public MutableRel[] getSlots() {
+    return slots;
   }
 
   private static MutableRel toMutable(RelNode rel) {
@@ -451,7 +456,8 @@ public class SubstitutionVisitor {
               final UnifyResult result = rule.apply(call);
               if (result != null) {
                 ++count;
-                result.call.query.replaceInParent(result.result);
+                MutableRel parent = result.call.query.replaceInParent(result.result);
+
                 // Replace previous equivalents with new equivalents, higher up
                 // the tree.
                 for (int i = 0; i < rule.slotCount; i++) {
@@ -606,7 +612,7 @@ public class SubstitutionVisitor {
     if (list == null) {
       final ImmutableList.Builder<UnifyRule> builder =
           ImmutableList.builder();
-      for (UnifyRule rule : RULES) {
+      for (UnifyRule rule : unifyRules) {
         //noinspection unchecked
         if (mightMatch(rule, queryClass, targetClass)) {
           builder.add(rule);
@@ -625,7 +631,7 @@ public class SubstitutionVisitor {
   }
 
   /** Exception thrown to exit a matcher. Not really an error. */
-  private static class MatchFailed extends ControlFlowException {
+  protected static class MatchFailed extends ControlFlowException {
     static final MatchFailed INSTANCE = new MatchFailed();
   }
 
@@ -635,7 +641,7 @@ public class SubstitutionVisitor {
    * <p>The rule declares the query and target types; this allows the
    * engine to fire only a few rules in a given context.</p>
    */
-  private abstract static class UnifyRule {
+  protected abstract static class UnifyRule {
     protected final int slotCount;
     protected final Operand queryOperand;
     protected final Operand targetOperand;
@@ -673,9 +679,9 @@ public class SubstitutionVisitor {
      *
      * @param call Input parameters
      */
-    abstract UnifyResult apply(UnifyRuleCall call);
+    protected abstract UnifyResult apply(UnifyRuleCall call);
 
-    UnifyRuleCall match(SubstitutionVisitor visitor, MutableRel query,
+    protected UnifyRuleCall match(SubstitutionVisitor visitor, MutableRel query,
         MutableRel target) {
       if (queryOperand.matches(visitor, query)) {
         if (targetOperand.matches(visitor, target)) {
@@ -686,7 +692,7 @@ public class SubstitutionVisitor {
       return null;
     }
 
-    private <E> ImmutableList<E> copy(E[] slots, int slotCount) {
+    protected <E> ImmutableList<E> copy(E[] slots, int slotCount) {
       // Optimize if there are 0 or 1 slots.
       switch (slotCount) {
       case 0:
@@ -702,11 +708,11 @@ public class SubstitutionVisitor {
   /**
    * Arguments to an application of a {@link UnifyRule}.
    */
-  private class UnifyRuleCall {
-    final UnifyRule rule;
-    final MutableRel query;
-    final MutableRel target;
-    final ImmutableList<MutableRel> slots;
+  protected class UnifyRuleCall {
+    protected final UnifyRule rule;
+    public final MutableRel query;
+    public final MutableRel target;
+    protected final ImmutableList<MutableRel> slots;
 
     public UnifyRuleCall(UnifyRule rule, MutableRel query, MutableRel target,
         ImmutableList<MutableRel> slots) {
@@ -716,7 +722,7 @@ public class SubstitutionVisitor {
       this.slots = Preconditions.checkNotNull(slots);
     }
 
-    UnifyResult result(MutableRel result) {
+    public UnifyResult result(MutableRel result) {
       assert MutableRels.contains(result, target);
       assert MutableRels.equalType("result", result, "query", query, true);
       MutableRel replace = replacementMap.get(target);
@@ -747,7 +753,7 @@ public class SubstitutionVisitor {
    * generated a {@code result} that is equivalent to {@code query} and
    * contains {@code target}.
    */
-  private static class UnifyResult {
+  protected static class UnifyResult {
     private final UnifyRuleCall call;
     // equivalent to "query", contains "result"
     private final MutableRel result;
@@ -760,7 +766,7 @@ public class SubstitutionVisitor {
   }
 
   /** Abstract base class for implementing {@link UnifyRule}. */
-  private abstract static class AbstractUnifyRule extends UnifyRule {
+  protected abstract static class AbstractUnifyRule extends UnifyRule {
     public AbstractUnifyRule(Operand queryOperand, Operand targetOperand,
         int slotCount) {
       super(slotCount, queryOperand, targetOperand);
@@ -781,24 +787,24 @@ public class SubstitutionVisitor {
     }
 
     /** Creates an operand with given inputs. */
-    static Operand operand(Class<? extends MutableRel> clazz,
+    protected static Operand operand(Class<? extends MutableRel> clazz,
         Operand... inputOperands) {
       return new InternalOperand(clazz, ImmutableList.copyOf(inputOperands));
     }
 
     /** Creates an operand that doesn't check inputs. */
-    static Operand any(Class<? extends MutableRel> clazz) {
+    protected static Operand any(Class<? extends MutableRel> clazz) {
       return new AnyOperand(clazz);
     }
 
     /** Creates an operand that matches a relational expression in the query. */
-    static Operand query(int ordinal) {
+    protected static Operand query(int ordinal) {
       return new QueryOperand(ordinal);
     }
 
     /** Creates an operand that matches a relational expression in the
      * target. */
-    static Operand target(int ordinal) {
+    protected static Operand target(int ordinal) {
       return new TargetOperand(ordinal);
     }
   }
@@ -854,6 +860,7 @@ public class SubstitutionVisitor {
     }
   }
 
+
   /** Implementation of {@link UnifyRule} that matches a {@link MutableFilter}
    * to a {@link MutableProject}. */
   private static class FilterToProjectUnifyRule extends AbstractUnifyRule {
@@ -893,7 +900,7 @@ public class SubstitutionVisitor {
       }
     }
 
-    private MutableRel invert(List<Pair<RexNode, String>> namedProjects,
+    protected MutableRel invert(List<Pair<RexNode, String>> namedProjects,
         MutableRel input,
         RexShuttle shuttle) {
       if (LOGGER.isLoggable(Level.FINER)) {
@@ -918,7 +925,7 @@ public class SubstitutionVisitor {
       return MutableProject.of(input, exprList, Pair.right(namedProjects));
     }
 
-    private MutableRel invert(MutableRel model, MutableRel input,
+    protected MutableRel invert(MutableRel model, MutableRel input,
         MutableProject project) {
       if (LOGGER.isLoggable(Level.FINER)) {
         LOGGER.finer("SubstitutionVisitor: invert:\n"
@@ -1252,7 +1259,7 @@ public class SubstitutionVisitor {
    * For this reason, you should use {@code MutableRel} for short-lived
    * operations, and transcribe back to {@code RelNode} when you are done.</p>
    */
-  private abstract static class MutableRel {
+  protected abstract static class MutableRel {
     MutableRel parent;
     int ordinalInParent;
     public final RelOptCluster cluster;
@@ -1311,6 +1318,8 @@ public class SubstitutionVisitor {
     @Override public final String toString() {
       return deep();
     }
+
+    public MutableRel getParent() { return parent; }
   }
 
   /** Implementation of {@link MutableRel} whose only purpose is to have a
@@ -1331,7 +1340,7 @@ public class SubstitutionVisitor {
 
    /** Abstract base class for implementations of {@link MutableRel} that have
    * no inputs. */
-  private abstract static class MutableLeafRel extends MutableRel {
+  protected abstract static class MutableLeafRel extends MutableRel {
     protected final RelNode rel;
 
     MutableLeafRel(MutableRelType type, RelNode rel) {
@@ -1353,7 +1362,7 @@ public class SubstitutionVisitor {
   }
 
   /** Mutable equivalent of {@link SingleRel}. */
-  private abstract static class MutableSingleRel extends MutableRel {
+  protected abstract static class MutableSingleRel extends MutableRel {
     protected MutableRel input;
 
     MutableSingleRel(MutableRelType type, RelDataType rowType,
@@ -1390,7 +1399,7 @@ public class SubstitutionVisitor {
 
   /** Mutable equivalent of
    * {@link org.apache.calcite.rel.logical.LogicalTableScan}. */
-  private static class MutableScan extends MutableLeafRel {
+  protected static class MutableScan extends MutableLeafRel {
     private MutableScan(TableScan rel) {
       super(MutableRelType.SCAN, rel);
     }
@@ -1416,7 +1425,7 @@ public class SubstitutionVisitor {
   }
 
   /** Mutable equivalent of {@link org.apache.calcite.rel.core.Values}. */
-  private static class MutableValues extends MutableLeafRel {
+  protected static class MutableValues extends MutableLeafRel {
     private MutableValues(Values rel) {
       super(MutableRelType.VALUES, rel);
     }
@@ -1443,7 +1452,7 @@ public class SubstitutionVisitor {
 
   /** Mutable equivalent of
    * {@link org.apache.calcite.rel.logical.LogicalProject}. */
-  private static class MutableProject extends MutableSingleRel {
+  protected static class MutableProject extends MutableSingleRel {
     private final List<RexNode> projects;
 
     private MutableProject(RelDataType rowType, MutableRel input,
@@ -1453,7 +1462,7 @@ public class SubstitutionVisitor {
       assert RexUtil.compatibleTypes(projects, rowType, true);
     }
 
-    static MutableProject of(RelDataType rowType, MutableRel input,
+    public static MutableProject of(RelDataType rowType, MutableRel input,
         List<RexNode> projects) {
       return new MutableProject(rowType, input, projects);
     }
@@ -1461,7 +1470,7 @@ public class SubstitutionVisitor {
     /** Equivalent to
      * {@link RelOptUtil#createProject(org.apache.calcite.rel.RelNode, java.util.List, java.util.List)}
      * for {@link MutableRel}. */
-    static MutableRel of(MutableRel child, List<RexNode> exprList,
+    public static MutableRel of(MutableRel child, List<RexNode> exprList,
         List<String> fieldNameList) {
       final RelDataType rowType =
           RexUtil.createStructType(child.cluster.getTypeFactory(), exprList,
@@ -1506,7 +1515,7 @@ public class SubstitutionVisitor {
 
   /** Mutable equivalent of
    * {@link org.apache.calcite.rel.logical.LogicalFilter}. */
-  private static class MutableFilter extends MutableSingleRel {
+  protected static class MutableFilter extends MutableSingleRel {
     private final RexNode condition;
 
     private MutableFilter(MutableRel input, RexNode condition) {
@@ -1514,7 +1523,7 @@ public class SubstitutionVisitor {
       this.condition = condition;
     }
 
-    static MutableFilter of(MutableRel input, RexNode condition) {
+    public static MutableFilter of(MutableRel input, RexNode condition) {
       return new MutableFilter(input, condition);
     }
 
@@ -1541,7 +1550,7 @@ public class SubstitutionVisitor {
 
   /** Mutable equivalent of
    * {@link org.apache.calcite.rel.logical.LogicalAggregate}. */
-  private static class MutableAggregate extends MutableSingleRel {
+  protected static class MutableAggregate extends MutableSingleRel {
     public final boolean indicator;
     private final ImmutableBitSet groupSet;
     private final ImmutableList<ImmutableBitSet> groupSets;
@@ -1605,7 +1614,7 @@ public class SubstitutionVisitor {
   }
 
   /** Mutable equivalent of {@link org.apache.calcite.rel.core.Sort}. */
-  private static class MutableSort extends MutableSingleRel {
+  protected static class MutableSort extends MutableSingleRel {
     private final RelCollation collation;
     private final RexNode offset;
     private final RexNode fetch;
@@ -1649,7 +1658,7 @@ public class SubstitutionVisitor {
   }
 
   /** Base class for set-operations. */
-  private abstract static class MutableSetOp extends MutableRel {
+  protected abstract static class MutableSetOp extends MutableRel {
     protected final List<MutableRel> inputs;
 
     private MutableSetOp(RelOptCluster cluster, RelDataType rowType,
@@ -1675,7 +1684,7 @@ public class SubstitutionVisitor {
 
   /** Mutable equivalent of
    * {@link org.apache.calcite.rel.logical.LogicalUnion}. */
-  private static class MutableUnion extends MutableSetOp {
+  protected static class MutableUnion extends MutableSetOp {
     public boolean all;
 
     private MutableUnion(RelOptCluster cluster, RelDataType rowType,
@@ -1814,7 +1823,7 @@ public class SubstitutionVisitor {
   }
 
   /** Utilities for dealing with {@link MutableRel}s. */
-  private static class MutableRels {
+  protected static class MutableRels {
     public static boolean contains(MutableRel ancestor,
         final MutableRel target) {
       if (ancestor.equals(target)) {
@@ -1945,7 +1954,7 @@ public class SubstitutionVisitor {
   }
 
   /** Visitor that prints an indented tree of {@link MutableRel}s. */
-  private static class MutableRelDumper extends MutableRelVisitor {
+  protected static class MutableRelDumper extends MutableRelVisitor {
     private final StringBuilder buf = new StringBuilder();
     private int level;
 
@@ -1969,14 +1978,16 @@ public class SubstitutionVisitor {
   }
 
   /** Operand to a {@link UnifyRule}. */
-  private abstract static class Operand {
+  protected abstract static class Operand {
     protected final Class<? extends MutableRel> clazz;
 
     protected Operand(Class<? extends MutableRel> clazz) {
       this.clazz = clazz;
     }
 
-    abstract boolean matches(SubstitutionVisitor visitor, MutableRel rel);
+    public abstract boolean matches(SubstitutionVisitor visitor, MutableRel rel);
+
+    public boolean isWeaker(SubstitutionVisitor visitor, MutableRel rel) { return false; }
   }
 
   /** Operand to a {@link UnifyRule} that matches a relational expression of a
@@ -1989,11 +2000,15 @@ public class SubstitutionVisitor {
       this.inputs = inputs;
     }
 
-    @Override boolean matches(SubstitutionVisitor visitor, MutableRel rel) {
+    @Override public boolean matches(SubstitutionVisitor visitor, MutableRel rel) {
       return clazz.isInstance(rel)
           && allMatch(visitor, inputs, rel.getInputs());
     }
 
+    @Override public boolean isWeaker(SubstitutionVisitor visitor, MutableRel rel) {
+      return clazz.isInstance(rel)
+              && allWeaker(visitor, inputs, rel.getInputs());
+    }
     private static boolean allMatch(SubstitutionVisitor visitor,
         List<Operand> operands, List<MutableRel> rels) {
       if (operands.size() != rels.size()) {
@@ -2001,6 +2016,19 @@ public class SubstitutionVisitor {
       }
       for (Pair<Operand, MutableRel> pair : Pair.zip(operands, rels)) {
         if (!pair.left.matches(visitor, pair.right)) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    private static boolean allWeaker(SubstitutionVisitor visitor,
+                                    List<Operand> operands, List<MutableRel> rels) {
+      if (operands.size() != rels.size()) {
+        return false;
+      }
+      for (Pair<Operand, MutableRel> pair : Pair.zip(operands, rels)) {
+        if (!pair.left.isWeaker(visitor, pair.right)) {
           return false;
         }
       }
@@ -2015,7 +2043,7 @@ public class SubstitutionVisitor {
       super(clazz);
     }
 
-    @Override boolean matches(SubstitutionVisitor visitor, MutableRel rel) {
+    @Override public boolean matches(SubstitutionVisitor visitor, MutableRel rel) {
       return clazz.isInstance(rel);
     }
   }
@@ -2036,7 +2064,7 @@ public class SubstitutionVisitor {
       this.ordinal = ordinal;
     }
 
-    @Override boolean matches(SubstitutionVisitor visitor, MutableRel rel) {
+    @Override public boolean matches(SubstitutionVisitor visitor, MutableRel rel) {
       visitor.slots[ordinal] = rel;
       return true;
     }
@@ -2052,10 +2080,32 @@ public class SubstitutionVisitor {
       this.ordinal = ordinal;
     }
 
-    @Override boolean matches(SubstitutionVisitor visitor, MutableRel rel) {
+    @Override public boolean matches(SubstitutionVisitor visitor, MutableRel rel) {
       final MutableRel rel0 = visitor.slots[ordinal];
       assert rel0 != null : "QueryOperand should have been called first";
       return rel0 == rel || visitor.equivalents.get(rel0).contains(rel);
+    }
+
+    @Override public boolean isWeaker(SubstitutionVisitor visitor, MutableRel rel) {
+      final MutableRel rel0 = visitor.slots[ordinal];
+      assert rel0 != null : "QueryOperand should have been called first";
+
+      if (rel0 == rel || visitor.equivalents.get(rel0).contains(rel)) {
+        return false;
+      }
+
+      if (!(rel0 instanceof MutableFilter)
+              || !(rel instanceof MutableFilter)) {
+        return false;
+      }
+
+      RexExecutorImpl rexImpl = (RexExecutorImpl) (rel.cluster.getPlanner().getExecutor());
+      plan.RexImplicationChecker rexImplicationChecker = new plan.RexImplicationChecker(
+              rel.cluster.getRexBuilder(),
+              rexImpl, rel.getRowType());
+
+      return rexImplicationChecker.implies(((MutableFilter) rel0).getCondition(),
+              ((MutableFilter) rel).getCondition());
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
@@ -642,7 +642,7 @@ public class SubstitutionVisitor {
 
   /** Exception thrown to exit a matcher. Not really an error. */
   protected static class MatchFailed extends ControlFlowException {
-    static final MatchFailed INSTANCE = new MatchFailed();
+    public static final MatchFailed INSTANCE = new MatchFailed();
   }
 
   /** Rule that attempts to match a query relational expression
@@ -2106,6 +2106,17 @@ public class SubstitutionVisitor {
 
       if (!(rel0 instanceof MutableFilter)
               || !(rel instanceof MutableFilter)) {
+        return false;
+      }
+
+      if (!rel.getRowType().equals(rel0.getRowType())) {
+        return false;
+      }
+
+      final MutableRel rel0input = ((MutableFilter) rel0).getInput();
+      final MutableRel relinput = ((MutableFilter) rel).getInput();
+      if (rel0input != relinput
+              && !visitor.equivalents.get(rel0input).contains(relinput)) {
         return false;
       }
 

--- a/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
@@ -147,7 +147,7 @@ public class SubstitutionVisitor {
 
   protected static List<UnifyRule> unifyRules;
 
-  protected static final Map<Pair<Class, Class>, List<UnifyRule>> RULE_MAP =
+  private static final Map<Pair<Class, Class>, List<UnifyRule>> RULE_MAP =
       new HashMap<>();
 
   private final RelOptCluster cluster;
@@ -2003,7 +2003,9 @@ public class SubstitutionVisitor {
 
     public abstract boolean matches(SubstitutionVisitor visitor, MutableRel rel);
 
-    public boolean isWeaker(SubstitutionVisitor visitor, MutableRel rel) { return false; }
+    public boolean isWeaker(SubstitutionVisitor visitor, MutableRel rel) {
+      return false;
+    }
   }
 
   /** Operand to a {@link UnifyRule} that matches a relational expression of a
@@ -2023,7 +2025,7 @@ public class SubstitutionVisitor {
 
     @Override public boolean isWeaker(SubstitutionVisitor visitor, MutableRel rel) {
       return clazz.isInstance(rel)
-              && allWeaker(visitor, inputs, rel.getInputs());
+          && allWeaker(visitor, inputs, rel.getInputs());
     }
     private static boolean allMatch(SubstitutionVisitor visitor,
         List<Operand> operands, List<MutableRel> rels) {
@@ -2038,8 +2040,9 @@ public class SubstitutionVisitor {
       return true;
     }
 
-    private static boolean allWeaker(SubstitutionVisitor visitor,
-                                    List<Operand> operands, List<MutableRel> rels) {
+    private static boolean allWeaker(
+        SubstitutionVisitor visitor,
+        List<Operand> operands, List<MutableRel> rels) {
       if (operands.size() != rels.size()) {
         return false;
       }
@@ -2111,7 +2114,7 @@ public class SubstitutionVisitor {
       }
 
       if (!(rel0 instanceof MutableFilter)
-              || !(rel instanceof MutableFilter)) {
+          || !(rel instanceof MutableFilter)) {
         return false;
       }
 
@@ -2122,17 +2125,18 @@ public class SubstitutionVisitor {
       final MutableRel rel0input = ((MutableFilter) rel0).getInput();
       final MutableRel relinput = ((MutableFilter) rel).getInput();
       if (rel0input != relinput
-              && !visitor.equivalents.get(rel0input).contains(relinput)) {
+          && !visitor.equivalents.get(rel0input).contains(relinput)) {
         return false;
       }
 
-      RexExecutorImpl rexImpl = (RexExecutorImpl) (rel.cluster.getPlanner().getExecutor());
-      plan.RexImplicationChecker rexImplicationChecker = new plan.RexImplicationChecker(
-              rel.cluster.getRexBuilder(),
-              rexImpl, rel.getRowType());
+      RexExecutorImpl rexImpl =
+          (RexExecutorImpl) (rel.cluster.getPlanner().getExecutor());
+      RexImplicationChecker rexImplicationChecker = new RexImplicationChecker(
+          rel.cluster.getRexBuilder(),
+          rexImpl, rel.getRowType());
 
       return rexImplicationChecker.implies(((MutableFilter) rel0).getCondition(),
-              ((MutableFilter) rel).getCondition());
+          ((MutableFilter) rel).getCondition());
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/plan/VisitorDataContext.java
+++ b/core/src/main/java/org/apache/calcite/plan/VisitorDataContext.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.plan;
+
+import org.apache.calcite.DataContext;
+import org.apache.calcite.adapter.java.JavaTypeFactory;
+import org.apache.calcite.linq4j.QueryProvider;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactoryImpl.JavaType;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlCastFunction;
+import org.apache.calcite.util.NlsString;
+import org.apache.calcite.util.Pair;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.util.List;
+
+/**
+ * DataContext for evaluating an RexExpression
+ */
+public class VisitorDataContext implements DataContext {
+  private final Object[] values;
+
+  public VisitorDataContext(Object[] values) {
+    this.values = values;
+  }
+
+  public SchemaPlus getRootSchema() {
+    throw new RuntimeException("Unsupported");
+  }
+
+  public JavaTypeFactory getTypeFactory() {
+    throw new RuntimeException("Unsupported");
+  }
+
+  public QueryProvider getQueryProvider() {
+    throw new RuntimeException("Unsupported");
+  }
+
+  public Object get(String name) {
+    if (name.equals("inputRecord")) {
+      return values;
+    } else {
+      return null;
+    }
+  }
+  public static DataContext getDataContext(RelNode targetRel, LogicalFilter queryRel) {
+    return getDataContext(targetRel.getRowType(), queryRel.getCondition());
+  }
+
+  public static DataContext getDataContext(RelDataType rowType, RexNode rex) {
+    int size = rowType.getFieldList().size();
+    Object[] values = new Object[size];
+    List<RexNode> operands = ((RexCall) rex).getOperands();
+    final RexNode firstOperand = operands.get(0);
+    final RexNode secondOperand = operands.get(1);
+    final Pair<Integer, ? extends Object> value = getValue(firstOperand, secondOperand);
+    if (value != null) {
+      int index = value.getKey();
+      values[index] = value.getValue();
+      return new VisitorDataContext(values);
+    } else {
+      return null;
+    }
+  }
+
+  public static DataContext getDataContext(RelDataType rowType, List<Pair<RexInputRef,
+          RexNode>> usgList) {
+    int size = rowType.getFieldList().size();
+    Object[] values = new Object[size];
+    for (Pair<RexInputRef, RexNode> elem: usgList) {
+      Pair<Integer, ? extends Object> value = getValue(elem.getKey(), elem.getValue());
+      if (value == null) {
+        return null;
+      }
+      int index = value.getKey();
+      values[index] = value.getValue();
+    }
+    return new VisitorDataContext(values);
+  }
+
+  public static Pair<Integer, ? extends Object> getValue(RexNode inputRef, RexNode literal) {
+    inputRef = removeCast(inputRef);
+    literal = removeCast(literal);
+
+    if (inputRef instanceof RexInputRef
+            && literal instanceof RexLiteral)  {
+      Integer index = ((RexInputRef) inputRef).getIndex();
+      Object value = ((RexLiteral) literal).getValue();
+      final Class javaClass = ((JavaType) (inputRef.getType())).getJavaClass();
+      if (javaClass == Integer.class
+              && value instanceof BigDecimal) {
+        final Integer intValue = new Integer(((BigDecimal) value).intValue());
+        return  Pair.of(index, intValue);
+      }
+      if (javaClass == Date.class
+              && value instanceof NlsString) {
+        value = ((RexLiteral) literal).getValue2();
+        final Date dateValue = Date.valueOf((String) value);
+        return Pair.of(index, dateValue);
+      }
+
+      if (javaClass == Double.class
+              && value instanceof BigDecimal) {
+        return Pair.of(index,
+                new Double(((BigDecimal) value).doubleValue()));
+      }
+      return Pair.of(index, value);
+    }
+
+    return null;
+  }
+
+  private static RexNode removeCast(RexNode inputRef) {
+    if (inputRef instanceof RexCall) {
+      final RexCall castedRef = (RexCall) inputRef;
+      final SqlOperator operator = castedRef.getOperator();
+      if (operator instanceof SqlCastFunction) {
+        inputRef = castedRef.getOperands().get(0);
+      }
+    }
+    return inputRef;
+  }
+}

--- a/core/src/main/java/org/apache/calcite/plan/VisitorDataContext.java
+++ b/core/src/main/java/org/apache/calcite/plan/VisitorDataContext.java
@@ -154,7 +154,7 @@ public class VisitorDataContext implements DataContext {
         }
       default:
         //TODO: Support few more supported cases
-        return null;
+        return Pair.of(index, value);
       }
     }
 

--- a/core/src/main/java/org/apache/calcite/plan/VisitorDataContext.java
+++ b/core/src/main/java/org/apache/calcite/plan/VisitorDataContext.java
@@ -35,6 +35,7 @@ import org.apache.calcite.util.Pair;
 
 import java.math.BigDecimal;
 import java.sql.Date;
+import java.util.Calendar;
 import java.util.List;
 
 /**
@@ -151,6 +152,16 @@ public class VisitorDataContext implements DataContext {
           value = ((RexLiteral) literal).getValue2();
           final Date dateValue = Date.valueOf((String) value);
           return Pair.of(index, dateValue);
+        } else if (value instanceof Calendar) {
+          final long timeInMillis = ((Calendar) value).getTimeInMillis();
+          return Pair.of(index, new Date(timeInMillis));
+        }
+      case CHAR:
+        if (value instanceof NlsString) {
+          // TODO: Support coallation. Not supported in {@link #NlsString} compare too.
+          final NlsString nl = (NlsString) value;
+          Character c = new Character(nl.getValue().charAt(0));
+          return Pair.of(index, c);
         }
       default:
         //TODO: Support few more supported cases

--- a/core/src/main/java/org/apache/calcite/plan/VisitorDataContext.java
+++ b/core/src/main/java/org/apache/calcite/plan/VisitorDataContext.java
@@ -88,7 +88,7 @@ public class VisitorDataContext implements DataContext {
   }
 
   public static DataContext getDataContext(RelDataType rowType, List<Pair<RexInputRef,
-          RexNode>> usgList) {
+      RexNode>> usgList) {
     int size = rowType.getFieldList().size();
     Object[] values = new Object[size];
     for (Pair<RexInputRef, RexNode> elem: usgList) {
@@ -107,7 +107,7 @@ public class VisitorDataContext implements DataContext {
     literal = removeCast(literal);
 
     if (inputRef instanceof RexInputRef
-            && literal instanceof RexLiteral)  {
+        && literal instanceof RexLiteral)  {
       Integer index = ((RexInputRef) inputRef).getIndex();
       Object value = ((RexLiteral) literal).getValue();
       final RelDataType type = inputRef.getType();
@@ -121,27 +121,27 @@ public class VisitorDataContext implements DataContext {
       case DOUBLE:
         if (value instanceof BigDecimal) {
           return Pair.of(index,
-                  new Double(((BigDecimal) value).doubleValue()));
+              new Double(((BigDecimal) value).doubleValue()));
         }
       case REAL:
         if (value instanceof BigDecimal) {
           return Pair.of(index,
-                  new Float(((BigDecimal) value).floatValue()));
+              new Float(((BigDecimal) value).floatValue()));
         }
       case BIGINT:
         if (value instanceof BigDecimal) {
           return Pair.of(index,
-                  new Long(((BigDecimal) value).longValue()));
+              new Long(((BigDecimal) value).longValue()));
         }
       case SMALLINT:
         if (value instanceof BigDecimal) {
           return Pair.of(index,
-                  new Short(((BigDecimal) value).shortValue()));
+              new Short(((BigDecimal) value).shortValue()));
         }
       case TINYINT:
         if (value instanceof BigDecimal) {
           return Pair.of(index,
-                  new Short(((BigDecimal) value).byteValue()));
+              new Short(((BigDecimal) value).byteValue()));
         }
       case DECIMAL:
         if (value instanceof BigDecimal) {

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
@@ -415,16 +415,20 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
     RelNode newRoot = new SubstitutionVisitor(target, root)
             .go(materialization.tableRel);
 
-    if (newRoot != null) {
-      root = newRoot;
+    if (newRoot == null) {
+      return mvSubstitute(root, materialization, target);
+    } else {
+      RelNode newRoot2 = mvSubstitute(newRoot, materialization, target);
+      return (newRoot2 == null) ? newRoot : newRoot2;
     }
-
-    RelNode newRoot2 = new MaterializedViewSubstitutionVisitor(target, root)
-            .go(materialization.tableRel);
-
-    return (newRoot2 == null) ? newRoot : newRoot2;
-
   }
+
+  private RelNode mvSubstitute(RelNode root, RelOptMaterialization materialization,
+                               RelNode target) {
+    return new MaterializedViewSubstitutionVisitor(target, root)
+              .go(materialization.tableRel);
+  }
+
 
   private void useApplicableMaterializations() {
     // Avoid using materializations while populating materializations!

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
@@ -23,6 +23,7 @@ import org.apache.calcite.plan.AbstractRelOptPlanner;
 import org.apache.calcite.plan.Context;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.ConventionTraitDef;
+import org.apache.calcite.plan.MaterializedViewSubstitutionVisitor;
 import org.apache.calcite.plan.RelOptCost;
 import org.apache.calcite.plan.RelOptCostFactory;
 import org.apache.calcite.plan.RelOptLattice;
@@ -38,7 +39,6 @@ import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.plan.RelTrait;
 import org.apache.calcite.plan.RelTraitDef;
 import org.apache.calcite.plan.RelTraitSet;
-import org.apache.calcite.plan.SubstitutionVisitor;
 import org.apache.calcite.plan.hep.HepPlanner;
 import org.apache.calcite.plan.hep.HepProgram;
 import org.apache.calcite.plan.hep.HepProgramBuilder;
@@ -105,8 +105,6 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import plan.MaterializedViewSubstitutionVisitor;
 
 import static org.apache.calcite.util.Stacks.peek;
 import static org.apache.calcite.util.Stacks.pop;
@@ -412,23 +410,9 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
     hepPlanner.setRoot(root);
     root = hepPlanner.findBestExp();
 
-    RelNode newRoot = new SubstitutionVisitor(target, root)
-            .go(materialization.tableRel);
-
-    if (newRoot == null) {
-      return mvSubstitute(root, materialization, target);
-    } else {
-      RelNode newRoot2 = mvSubstitute(newRoot, materialization, target);
-      return (newRoot2 == null) ? newRoot : newRoot2;
-    }
-  }
-
-  private RelNode mvSubstitute(RelNode root, RelOptMaterialization materialization,
-                               RelNode target) {
     return new MaterializedViewSubstitutionVisitor(target, root)
-              .go(materialization.tableRel);
+            .go(materialization.tableRel);
   }
-
 
   private void useApplicableMaterializations() {
     // Avoid using materializations while populating materializations!

--- a/core/src/test/java/org/apache/calcite/test/CalciteSuite.java
+++ b/core/src/test/java/org/apache/calcite/test/CalciteSuite.java
@@ -114,6 +114,7 @@ import org.junit.runners.Suite;
     // slow tests (above 1s)
     PlannerTest.class,
     RelBuilderTest.class,
+    RexImplicationCheckerTest.class,
     MaterializationTest.class,
     JdbcAdapterTest.class,
     LinqFrontJdbcBackTest.class,

--- a/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
@@ -179,7 +179,8 @@ public class MaterializationTest {
         + "from \"emps\" where \"deptno\" - 10 = 2",
         JdbcTest.HR_MODEL,
         CalciteAssert.checkResultContains(
-            "EnumerableCalc(expr#0..2=[{inputs}], expr#3=[2], expr#4=[=($t0, $t3)], name=[$t2], E=[$t1], $condition=[$t4])\n"
+            "EnumerableCalc(expr#0..2=[{inputs}], expr#3=[2], "
+                + "expr#4=[=($t0, $t3)], name=[$t2], E=[$t1], $condition=[$t4])\n"
                 + "  EnumerableTableScan(table=[[hr, m0]]"));
   }
 
@@ -212,7 +213,8 @@ public class MaterializationTest {
   @Test public void testFilterQueryOnFilterView2() {
     checkMaterialize(
         "select \"deptno\", \"empid\", \"name\" from \"emps\" where \"deptno\" = 10",
-        "select \"empid\" + 1 as x, \"name\" from \"emps\" where \"deptno\" = 10 and \"empid\" < 150");
+        "select \"empid\" + 1 as x, \"name\" from \"emps\" "
+            + "where \"deptno\" = 10 and \"empid\" < 150");
   }
 
   /** As {@link #testFilterQueryOnFilterView()} but condition is weaker in
@@ -220,11 +222,13 @@ public class MaterializationTest {
   @Ignore("not implemented")
   @Test public void testFilterQueryOnFilterView3() {
     checkMaterialize(
-        "select \"deptno\", \"empid\", \"name\" from \"emps\" where \"deptno\" = 10 or \"deptno\" = 20 or \"empid\" < 160",
+        "select \"deptno\", \"empid\", \"name\" from \"emps\" "
+            + "where \"deptno\" = 10 or \"deptno\" = 20 or \"empid\" < 160",
         "select \"empid\" + 1 as x, \"name\" from \"emps\" where \"deptno\" = 10",
         JdbcTest.HR_MODEL,
         CalciteAssert.checkResultContains(
-            "EnumerableCalcRel(expr#0..2=[{inputs}], expr#3=[1], expr#4=[+($t1, $t3)], X=[$t4], name=[$t2], condition=?)\n"
+            "EnumerableCalcRel(expr#0..2=[{inputs}], expr#3=[1], "
+                + "expr#4=[+($t1, $t3)], X=[$t4], name=[$t2], condition=?)\n"
                 + "  EnumerableTableScan(table=[[hr, m0]])"));
   }
 
@@ -248,7 +252,8 @@ public class MaterializationTest {
    * query and columns selected are subset of columns in materialized view */
   @Test public void testFilterQueryOnFilterView6() {
     checkMaterialize(
-            "select \"name\", \"deptno\", \"salary\" from \"emps\" where \"salary\" > 2000.5",
+            "select \"name\", \"deptno\", \"salary\" from \"emps\" "
+                + "where \"salary\" > 2000.5",
             "select \"name\" from \"emps\" where \"deptno\" > 30 and \"salary\" > 3000");
   }
 
@@ -258,11 +263,11 @@ public class MaterializationTest {
   @Test public void testFilterQueryOnFilterView7() {
     checkMaterialize(
             "select * from \"emps\" where "
-                    + "((\"salary\" < 1111.9 and \"deptno\" > 10)"
-                    + "or (\"empid\" > 400 and \"salary\" > 5000) "
-                    + "or \"salary\" > 500)",
+                + "((\"salary\" < 1111.9 and \"deptno\" > 10)"
+                + "or (\"empid\" > 400 and \"salary\" > 5000) "
+                + "or \"salary\" > 500)",
             "select \"name\" from \"emps\" where (\"salary\" > 1000 "
-                    + "or (\"deptno\" >= 30 and \"salary\" <= 500))");
+                + "or (\"deptno\" >= 30 and \"salary\" <= 500))");
   }
 
   /** As {@link #testFilterQueryOnFilterView()} but condition is stronger in
@@ -280,11 +285,13 @@ public class MaterializationTest {
   @Test public void testFilterQueryOnFilterView9() {
     checkNoMaterialize(
             "select \"name\", \"deptno\" from \"emps\" where \"deptno\" > 10",
-            "select \"name\", \"empid\" from \"emps\" where \"deptno\" > 30 or \"empid\" > 10",
+            "select \"name\", \"empid\" from \"emps\" "
+                + "where \"deptno\" > 30 or \"empid\" > 10",
             JdbcTest.HR_MODEL);
   }
-  /** As {@link #testFilterQueryOnFilterView()} but condition currently has unsupported type being checked on
-   * query.*/
+  /** As {@link #testFilterQueryOnFilterView()} but condition currently
+   * has unsupported type being checked on query.
+   */
   @Test public void testFilterQueryOnFilterView10() {
     checkNoMaterialize(
             "select \"name\", \"deptno\" from \"emps\" where \"deptno\" > 10 "
@@ -306,8 +313,9 @@ public class MaterializationTest {
             JdbcTest.HR_MODEL);
   }
 
-  /** As {@link #testFilterQueryOnFilterView()} but condition of query is stronger but is
-   * on the column not present in MV (salary). */
+  /** As {@link #testFilterQueryOnFilterView()} but condition of
+   * query is stronger but is on the column not present in MV (salary).
+   */
   @Test public void testFilterQueryOnFilterView12() {
     checkNoMaterialize(
             "select \"name\", \"deptno\" from \"emps\" where \"salary\" > 2000.5",
@@ -352,11 +360,13 @@ public class MaterializationTest {
    * COUNT is rolled up using SUM. */
   @Test public void testAggregateRollUp() {
     checkMaterialize(
-        "select \"empid\", \"deptno\", count(*) as c, sum(\"empid\") as s from \"emps\" group by \"empid\", \"deptno\"",
+        "select \"empid\", \"deptno\", count(*) as c, sum(\"empid\") as s from \"emps\" "
+            + "group by \"empid\", \"deptno\"",
         "select count(*) + 1 as c, \"deptno\" from \"emps\" group by \"deptno\"",
         JdbcTest.HR_MODEL,
         CalciteAssert.checkResultContains(
-            "EnumerableCalc(expr#0..1=[{inputs}], expr#2=[1], expr#3=[+($t1, $t2)], C=[$t3], deptno=[$t0])\n"
+            "EnumerableCalc(expr#0..1=[{inputs}], expr#2=[1], "
+                + "expr#3=[+($t1, $t2)], C=[$t3], deptno=[$t0])\n"
                 + "  EnumerableAggregate(group=[{1}], agg#0=[$SUM0($2)])\n"
                 + "    EnumerableTableScan(table=[[hr, m0]])"));
   }

--- a/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
@@ -245,12 +245,86 @@ public class MaterializationTest {
   }
 
   /** As {@link #testFilterQueryOnFilterView()} but condition is stronger in
+   * query and columns selected are subset of columns in materialized view */
+  @Test public void testFilterQueryOnFilterView6() {
+    checkMaterialize(
+            "select \"name\", \"deptno\", \"salary\" from \"emps\" where \"salary\" > 2000.5",
+            "select \"name\" from \"emps\" where \"deptno\" > 30 and \"salary\" > 3000");
+  }
+
+  /** As {@link #testFilterQueryOnFilterView()} but condition is stronger in
+   * query and columns selected are subset of columns in materialized view
+   * Condition here is complex*/
+  @Test public void testFilterQueryOnFilterView7() {
+    checkMaterialize(
+            "select * from \"emps\" where "
+                    + "((\"salary\" < 1111.9 and \"deptno\" > 10)"
+                    + "or (\"empid\" > 400 and \"salary\" > 5000) "
+                    + "or \"salary\" > 500)",
+            "select \"name\" from \"emps\" where (\"salary\" > 1000 "
+                    + "or (\"deptno\" >= 30 and \"salary\" <= 500))");
+  }
+
+  /** As {@link #testFilterQueryOnFilterView()} but condition is stronger in
    * query. However, columns selected are not present in columns of materialized view,
    * hence should not use materialized view*/
-  @Test public void testFilterQueryOnFilterView6() {
+  @Test public void testFilterQueryOnFilterView8() {
     checkNoMaterialize(
             "select \"name\", \"deptno\" from \"emps\" where \"deptno\" > 10",
             "select \"name\", \"empid\" from \"emps\" where \"deptno\" > 30",
+            JdbcTest.HR_MODEL);
+  }
+
+  /** As {@link #testFilterQueryOnFilterView()} but condition is weaker in
+   * query.*/
+  @Test public void testFilterQueryOnFilterView9() {
+    checkNoMaterialize(
+            "select \"name\", \"deptno\" from \"emps\" where \"deptno\" > 10",
+            "select \"name\", \"empid\" from \"emps\" where \"deptno\" > 30 or \"empid\" > 10",
+            JdbcTest.HR_MODEL);
+  }
+  /** As {@link #testFilterQueryOnFilterView()} but condition currently has unsupported type being checked on
+   * query.*/
+  @Test public void testFilterQueryOnFilterView10() {
+    checkNoMaterialize(
+            "select \"name\", \"deptno\" from \"emps\" where \"deptno\" > 10 "
+                    + "and \"name\" = \'calcite\'",
+            "select \"name\", \"empid\" from \"emps\" where \"deptno\" > 30 "
+                    + "or \"empid\" > 10",
+            JdbcTest.HR_MODEL);
+  }
+
+  /** As {@link #testFilterQueryOnFilterView()} but condition is weaker in
+   * query and columns selected are subset of columns in materialized view
+   * Condition here is complex*/
+  @Test public void testFilterQueryOnFilterView11() {
+    checkNoMaterialize(
+            "select \"name\", \"deptno\" from \"emps\" where "
+                    + "(\"salary\" < 1111.9 and \"deptno\" > 10)"
+                    + "or (\"empid\" > 400 and \"salary\" > 5000)",
+            "select \"name\" from \"emps\" where \"deptno\" > 30 and \"salary\" > 3000",
+            JdbcTest.HR_MODEL);
+  }
+
+  /** As {@link #testFilterQueryOnFilterView()} but condition of query is stronger but is
+   * on the column not present in MV (salary). */
+  @Test public void testFilterQueryOnFilterView12() {
+    checkNoMaterialize(
+            "select \"name\", \"deptno\" from \"emps\" where \"salary\" > 2000.5",
+            "select \"name\" from \"emps\" where \"deptno\" > 30 and \"salary\" > 3000",
+            JdbcTest.HR_MODEL);
+  }
+
+  /** As {@link #testFilterQueryOnFilterView()} but condition is weaker in
+   * query and columns selected are subset of columns in materialized view
+   * Condition here is complex*/
+  @Test public void testFilterQueryOnFilterView13() {
+    checkNoMaterialize(
+            "select * from \"emps\" where "
+                    + "(\"salary\" < 1111.9 and \"deptno\" > 10)"
+                    + "or (\"empid\" > 400 and \"salary\" > 5000)",
+            "select \"name\" from \"emps\" where \"salary\" > 1000 "
+                    + "or (\"deptno\" > 30 and \"salary\" > 3000)",
             JdbcTest.HR_MODEL);
   }
 

--- a/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
@@ -228,6 +228,14 @@ public class MaterializationTest {
                 + "  EnumerableTableScan(table=[[hr, m0]])"));
   }
 
+  /** As {@link #testFilterQueryOnFilterView()} but condition is stronger in
+   * query. */
+  @Test public void testFilterQueryOnFilterView4() {
+    checkMaterialize(
+            "select * where \"deptno\" = 10",
+            "select \"name\" from \"emps\" where \"deptno\" = 30");
+  }
+
   /** Aggregation query at same level of aggregation as aggregation
    * materialization. */
   @Test public void testAggregate() {

--- a/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
@@ -232,8 +232,26 @@ public class MaterializationTest {
    * query. */
   @Test public void testFilterQueryOnFilterView4() {
     checkMaterialize(
-            "select * where \"deptno\" = 10",
-            "select \"name\" from \"emps\" where \"deptno\" = 30");
+            "select * from \"emps\" where \"deptno\" > 10",
+            "select \"name\" from \"emps\" where \"deptno\" > 30");
+  }
+
+  /** As {@link #testFilterQueryOnFilterView()} but condition is stronger in
+   * query and columns selected are subset of columns in materialized view */
+  @Test public void testFilterQueryOnFilterView5() {
+    checkMaterialize(
+            "select \"name\", \"deptno\" from \"emps\" where \"deptno\" > 10",
+            "select \"name\" from \"emps\" where \"deptno\" > 30");
+  }
+
+  /** As {@link #testFilterQueryOnFilterView()} but condition is stronger in
+   * query. However, columns selected are not present in columns of materialized view,
+   * hence should not use materialized view*/
+  @Test public void testFilterQueryOnFilterView6() {
+    checkNoMaterialize(
+            "select \"name\", \"deptno\" from \"emps\" where \"deptno\" > 10",
+            "select \"name\", \"empid\" from \"emps\" where \"deptno\" > 30",
+            JdbcTest.HR_MODEL);
   }
 
   /** Aggregation query at same level of aggregation as aggregation

--- a/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
@@ -328,6 +328,17 @@ public class MaterializationTest {
             JdbcTest.HR_MODEL);
   }
 
+  /** As {@link #testFilterQueryOnFilterView13()} but using alias
+   * and condition of query is stronger*/
+  @Test public void testAlias() {
+    checkMaterialize(
+            "select * from \"emps\" as em where "
+                    + "(em.\"salary\" < 1111.9 and em.\"deptno\" > 10)"
+                    + "or (em.\"empid\" > 400 and em.\"salary\" > 5000)",
+            "select \"name\" as n from \"emps\" as e where "
+                    + "(e.\"empid\" > 500 and e.\"salary\" > 6000)");
+  }
+
   /** Aggregation query at same level of aggregation as aggregation
    * materialization. */
   @Test public void testAggregate() {
@@ -706,6 +717,13 @@ public class MaterializationTest {
         + "from (select * from \"emps\" union all select * from \"emps\")\n"
         + "join \"depts\" using (\"deptno\")";
     checkNoMaterialize(q, q, JdbcTest.HR_MODEL);
+  }
+
+  @Test public void testJoinMaterialization() {
+    String q = "select *\n"
+            + "from (select * from \"emps\" where \"empid\" < 300)\n"
+            + "join \"depts\" using (\"deptno\")";
+    checkMaterialize("select * from \"emps\" where \"empid\" < 500", q);
   }
 }
 

--- a/core/src/test/java/org/apache/calcite/test/RexImplicationCheckerTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RexImplicationCheckerTest.java
@@ -30,11 +30,13 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.Schemas;
 import org.apache.calcite.server.CalciteServerStatement;
+import org.apache.calcite.sql.SqlCollation;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
-
 import org.apache.calcite.tools.Frameworks;
+import org.apache.calcite.util.NlsString;
 
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import plan.RexImplicationChecker;
@@ -43,6 +45,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Calendar;
+
 /**
  * Tests the RexImplication checker
  */
@@ -50,14 +57,29 @@ public class RexImplicationCheckerTest {
   //~ Instance fields --------------------------------------------------------
 
   static RexBuilder rexBuilder = null;
-  static RexNode a;
-  static RexNode b;
-  static RexNode c;
-  static RexNode trueRex;
-  static RexNode falseRex;
+  static RexNode bl;
+  static RexNode i;
+  static RexNode dec;
+  static RexNode lg;
+  static RexNode sh;
+  static RexNode by;
+  static RexNode fl;
+  static RexNode dt;
+  static RexNode ch;
+  static RexNode ts;
+  static RexNode t;
+
   static RelDataType boolRelDataType;
   static RelDataType intRelDataType;
   static RelDataType decRelDataType;
+  static RelDataType longRelDataType;
+  static RelDataType shortDataType;
+  static RelDataType byteDataType;
+  static RelDataType floatDataType;
+  static RelDataType charDataType;
+  static RelDataType dateDataType;
+  static RelDataType timeStampDataType;
+  static RelDataType timeDataType;
   static RelDataTypeFactory typeFactory;
   static RexImplicationChecker checker;
   static RelDataType rowType;
@@ -72,22 +94,61 @@ public class RexImplicationCheckerTest {
     boolRelDataType = typeFactory.createJavaType(Boolean.class);
     intRelDataType = typeFactory.createJavaType(Integer.class);
     decRelDataType = typeFactory.createJavaType(Double.class);
+    longRelDataType = typeFactory.createJavaType(Long.class);
+    shortDataType = typeFactory.createJavaType(Short.class);
+    byteDataType = typeFactory.createJavaType(Byte.class);
+    floatDataType = typeFactory.createJavaType(Float.class);
+    charDataType = typeFactory.createJavaType(Character.class);
+    dateDataType = typeFactory.createJavaType(Date.class);
+    timeStampDataType = typeFactory.createJavaType(Timestamp.class);
+    timeDataType = typeFactory.createJavaType(Time.class);
 
-    a = new RexInputRef(
+    bl = new RexInputRef(
             0,
             typeFactory.createTypeWithNullability(boolRelDataType, true));
-    b = new RexInputRef(
+    i = new RexInputRef(
             1,
             typeFactory.createTypeWithNullability(intRelDataType, true));
-    c = new RexInputRef(
+    dec = new RexInputRef(
             2,
             typeFactory.createTypeWithNullability(decRelDataType, true));
-    trueRex = rexBuilder.makeLiteral(true);
-    falseRex = rexBuilder.makeLiteral(false);
+    lg = new RexInputRef(
+            3,
+            typeFactory.createTypeWithNullability(longRelDataType, true));
+    sh = new RexInputRef(
+            4,
+            typeFactory.createTypeWithNullability(shortDataType, true));
+    by = new RexInputRef(
+            5,
+            typeFactory.createTypeWithNullability(byteDataType, true));
+    fl = new RexInputRef(
+            6,
+            typeFactory.createTypeWithNullability(floatDataType, true));
+    ch = new RexInputRef(
+            7,
+            typeFactory.createTypeWithNullability(charDataType, true));
+    dt = new RexInputRef(
+            8,
+            typeFactory.createTypeWithNullability(dateDataType, true));
+    ts = new RexInputRef(
+            9,
+            typeFactory.createTypeWithNullability(timeStampDataType, true));
+    t = new RexInputRef(
+            10,
+            typeFactory.createTypeWithNullability(timeDataType, true));
+
     rowType =  typeFactory.builder()
             .add("bool", boolRelDataType)
             .add("int", intRelDataType)
             .add("dec", decRelDataType)
+            .add("long", longRelDataType)
+            .add("short", shortDataType)
+            .add("byte", byteDataType)
+            .add("float", floatDataType)
+            .add("char", charDataType)
+            .add("date", dateDataType)
+            .add("timestamp", timeStampDataType)
+            .add("time", timeDataType)
             .build();
 
     Frameworks.withPrepare(
@@ -116,42 +177,42 @@ public class RexImplicationCheckerTest {
             checker.implies(node1, node2));
   }
 
-
+  // Simple Tests for Operators
   @Test public void testSimpleGreaterCond() {
     RexNode node1 =
             rexBuilder.makeCall(
                     SqlStdOperatorTable.GREATER_THAN,
-                    b,
+                    i,
                     rexBuilder.makeExactLiteral(new BigDecimal(10)));
 
     RexNode node2 =
             rexBuilder.makeCall(
                     SqlStdOperatorTable.GREATER_THAN,
-                    b,
+                    i,
                     rexBuilder.makeExactLiteral(new BigDecimal(30)));
 
     RexNode node3 =
             rexBuilder.makeCall(
                     SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
-                    b,
+                    i,
                     rexBuilder.makeExactLiteral(new BigDecimal(30)));
 
     RexNode node4 =
             rexBuilder.makeCall(
                     SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
-                    b,
+                    i,
                     rexBuilder.makeExactLiteral(new BigDecimal(10)));
 
     RexNode node5 =
             rexBuilder.makeCall(
                     SqlStdOperatorTable.EQUALS,
-                    b,
+                    i,
                     rexBuilder.makeExactLiteral(new BigDecimal(30)));
 
     RexNode node6 =
             rexBuilder.makeCall(
                     SqlStdOperatorTable.NOT_EQUALS,
-                    b,
+                    i,
                     rexBuilder.makeExactLiteral(new BigDecimal(10)));
 
     checkImplies(node2, node1);
@@ -171,37 +232,37 @@ public class RexImplicationCheckerTest {
     RexNode node1 =
             rexBuilder.makeCall(
                     SqlStdOperatorTable.LESS_THAN,
-                    b,
+                    i,
                     rexBuilder.makeExactLiteral(new BigDecimal(10)));
 
     RexNode node2 =
             rexBuilder.makeCall(
                     SqlStdOperatorTable.LESS_THAN,
-                    b,
+                    i,
                     rexBuilder.makeExactLiteral(new BigDecimal(30)));
 
     RexNode node3 =
             rexBuilder.makeCall(
                     SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
-                    b,
+                    i,
                     rexBuilder.makeExactLiteral(new BigDecimal(30)));
 
     RexNode node4 =
             rexBuilder.makeCall(
                     SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
-                    b,
+                    i,
                     rexBuilder.makeExactLiteral(new BigDecimal(10)));
 
     RexNode node5 =
             rexBuilder.makeCall(
                     SqlStdOperatorTable.EQUALS,
-                    b,
+                    i,
                     rexBuilder.makeExactLiteral(new BigDecimal(10)));
 
     RexNode node6 =
             rexBuilder.makeCall(
                     SqlStdOperatorTable.NOT_EQUALS,
-                    b,
+                    i,
                     rexBuilder.makeExactLiteral(new BigDecimal(10)));
 
     checkImplies(node1, node2);
@@ -222,19 +283,165 @@ public class RexImplicationCheckerTest {
     RexNode node1 =
             rexBuilder.makeCall(
                     SqlStdOperatorTable.EQUALS,
-                    b,
+                    i,
                     rexBuilder.makeExactLiteral(new BigDecimal(30)));
 
     RexNode node2 =
             rexBuilder.makeCall(
                     SqlStdOperatorTable.NOT_EQUALS,
-                    b,
+                    i,
                     rexBuilder.makeExactLiteral(new BigDecimal(10)));
 
     //Check Identity
     checkImplies(node1, node1);
     //TODO: Support Identity
     // checkImplies(node2, node2);
+    checkImplies(node1, node2);
+    checkNotImplies(node2, node1);
+  }
+
+  // Simple Tests for DataTypes
+  @Test public void testSimpleDec() {
+    RexNode node1 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.LESS_THAN,
+                    dec,
+                    rexBuilder.makeApproxLiteral(new BigDecimal(30.9)));
+
+    RexNode node2 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.LESS_THAN,
+                    dec,
+                    rexBuilder.makeApproxLiteral(new BigDecimal(40.33)));
+
+    checkImplies(node1, node2);
+    checkNotImplies(node2, node1);
+  }
+
+  @Test public void testSimpleBoolean() {
+    RexNode node1 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.EQUALS,
+                    bl,
+                    rexBuilder.makeLiteral(true));
+
+    RexNode node2 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.EQUALS,
+                    bl,
+                    rexBuilder.makeLiteral(false));
+
+    //TODO: Need to support false => true
+    //checkImplies(node2, node1);
+    checkNotImplies(node1, node2);
+  }
+
+  @Test public void testSimpleLong() {
+    RexNode node1 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+                    lg,
+                    rexBuilder.makeLiteral(new Long(324324L), longRelDataType, true));
+
+    RexNode node2 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.GREATER_THAN,
+                    lg,
+                    rexBuilder.makeLiteral(new Long(324325L), longRelDataType, true));
+
+    checkImplies(node2, node1);
+    checkNotImplies(node1, node2);
+  }
+
+  @Test public void testSimpleShort() {
+    RexNode node1 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+                    sh,
+                    rexBuilder.makeLiteral(new Short((short) 10), shortDataType, true));
+
+    RexNode node2 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+                    sh,
+                    rexBuilder.makeLiteral(new Short((short) 11), shortDataType, true));
+
+    checkImplies(node2, node1);
+    checkNotImplies(node1, node2);
+  }
+
+  @Test public void testSimpleChar() {
+    RexNode node1 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+                    ch,
+                    rexBuilder.makeCharLiteral(new NlsString("b", null, SqlCollation.COERCIBLE)));
+
+    RexNode node2 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+                    ch,
+                    rexBuilder.makeCharLiteral(new NlsString("a", null, SqlCollation.COERCIBLE)));
+
+    checkImplies(node1, node2);
+    checkNotImplies(node2, node1);
+  }
+
+  @Test public void testSimpleDate() {
+    RexNode node1 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+                    dt,
+                    rexBuilder.makeDateLiteral(Calendar.getInstance()));
+
+    RexNode node2 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.EQUALS,
+                    dt,
+                    rexBuilder.makeDateLiteral(Calendar.getInstance()));
+
+    checkImplies(node2, node1);
+    checkNotImplies(node1, node2);
+  }
+
+  @Ignore("work in progress")
+  @Test public void testSimpleTimeStamp() {
+    RexNode node1 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
+                    ts,
+                    rexBuilder.makeTimestampLiteral(Calendar.getInstance(),
+                            timeStampDataType.getPrecision()));
+
+
+    RexNode node2 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
+                    ts,
+                    rexBuilder.makeTimestampLiteral(Calendar.getInstance(),
+                            timeStampDataType.getPrecision()));
+
+    checkImplies(node1, node2);
+    checkNotImplies(node2, node1);
+  }
+
+  @Ignore("work in progress")
+  @Test public void testSimpleTime() {
+    RexNode node1 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
+                    t,
+                    rexBuilder.makeTimeLiteral(Calendar.getInstance(),
+                            timeDataType.getPrecision()));
+
+
+    RexNode node2 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
+                    t,
+                    rexBuilder.makeTimestampLiteral(Calendar.getInstance(),
+                            timeDataType.getPrecision()));
+
     checkImplies(node1, node2);
     checkNotImplies(node2, node1);
   }

--- a/core/src/test/java/org/apache/calcite/test/RexImplicationCheckerTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RexImplicationCheckerTest.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.test;
+
+import org.apache.calcite.DataContext;
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptSchema;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexExecutorImpl;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.Schemas;
+import org.apache.calcite.server.CalciteServerStatement;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+
+import org.apache.calcite.tools.Frameworks;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import plan.RexImplicationChecker;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.math.BigDecimal;
+/**
+ * Tests the RexImplication checker
+ */
+public class RexImplicationCheckerTest {
+  //~ Instance fields --------------------------------------------------------
+
+  static RexBuilder rexBuilder = null;
+  static RexNode a;
+  static RexNode b;
+  static RexNode c;
+  static RexNode trueRex;
+  static RexNode falseRex;
+  static RelDataType boolRelDataType;
+  static RelDataType intRelDataType;
+  static RelDataType decRelDataType;
+  static RelDataTypeFactory typeFactory;
+  static RexImplicationChecker checker;
+  static RelDataType rowType;
+  static RexExecutorImpl executor;
+
+  //~ Methods ----------------------------------------------------------------
+
+  @BeforeClass
+  public static void setUp() {
+    typeFactory = new JavaTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+    rexBuilder = new RexBuilder(typeFactory);
+    boolRelDataType = typeFactory.createJavaType(Boolean.class);
+    intRelDataType = typeFactory.createJavaType(Integer.class);
+    decRelDataType = typeFactory.createJavaType(Double.class);
+
+    a = new RexInputRef(
+            0,
+            typeFactory.createTypeWithNullability(boolRelDataType, true));
+    b = new RexInputRef(
+            1,
+            typeFactory.createTypeWithNullability(intRelDataType, true));
+    c = new RexInputRef(
+            2,
+            typeFactory.createTypeWithNullability(decRelDataType, true));
+    trueRex = rexBuilder.makeLiteral(true);
+    falseRex = rexBuilder.makeLiteral(false);
+    rowType =  typeFactory.builder()
+            .add("bool", boolRelDataType)
+            .add("int", intRelDataType)
+            .add("dec", decRelDataType)
+            .build();
+
+    Frameworks.withPrepare(
+        new Frameworks.PrepareAction<Void>() {
+          public Void apply(RelOptCluster cluster,
+                            RelOptSchema relOptSchema,
+                            SchemaPlus rootSchema,
+                            CalciteServerStatement statement) {
+            DataContext dataContext =
+                    Schemas.createDataContext(statement.getConnection());
+            executor = new RexExecutorImpl(dataContext);
+            return null;
+          }
+        });
+
+    checker = new RexImplicationChecker(rexBuilder, executor, rowType);
+  }
+
+  private void checkImplies(RexNode node1, RexNode node2) {
+    assertTrue(node1.toString() + " doesnot imply " + node2.toString() + " when it should.",
+            checker.implies(node1, node2));
+  }
+
+  private void checkNotImplies(RexNode node1, RexNode node2) {
+    assertFalse(node1.toString() + " implies " + node2.toString() + " when it should not",
+            checker.implies(node1, node2));
+  }
+
+
+  @Test public void testSimpleGreaterCond() {
+    RexNode node1 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.GREATER_THAN,
+                    b,
+                    rexBuilder.makeExactLiteral(new BigDecimal(10)));
+
+    RexNode node2 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.GREATER_THAN,
+                    b,
+                    rexBuilder.makeExactLiteral(new BigDecimal(30)));
+
+    RexNode node3 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+                    b,
+                    rexBuilder.makeExactLiteral(new BigDecimal(30)));
+
+    RexNode node4 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+                    b,
+                    rexBuilder.makeExactLiteral(new BigDecimal(10)));
+
+    RexNode node5 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.EQUALS,
+                    b,
+                    rexBuilder.makeExactLiteral(new BigDecimal(30)));
+
+    RexNode node6 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.NOT_EQUALS,
+                    b,
+                    rexBuilder.makeExactLiteral(new BigDecimal(10)));
+
+    checkImplies(node2, node1);
+    checkNotImplies(node1, node2);
+    checkNotImplies(node1, node3);
+    checkImplies(node3, node1);
+    checkImplies(node5, node1);
+    checkNotImplies(node1, node5);
+    checkNotImplies(node1, node6);
+    checkNotImplies(node4, node6);
+    // TODO: Need to support Identity
+    //checkImplies(node1, node1);
+    //checkImplies(node3, node3);
+  }
+
+  @Test public void testSimpleLesserCond() {
+    RexNode node1 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.LESS_THAN,
+                    b,
+                    rexBuilder.makeExactLiteral(new BigDecimal(10)));
+
+    RexNode node2 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.LESS_THAN,
+                    b,
+                    rexBuilder.makeExactLiteral(new BigDecimal(30)));
+
+    RexNode node3 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
+                    b,
+                    rexBuilder.makeExactLiteral(new BigDecimal(30)));
+
+    RexNode node4 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
+                    b,
+                    rexBuilder.makeExactLiteral(new BigDecimal(10)));
+
+    RexNode node5 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.EQUALS,
+                    b,
+                    rexBuilder.makeExactLiteral(new BigDecimal(10)));
+
+    RexNode node6 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.NOT_EQUALS,
+                    b,
+                    rexBuilder.makeExactLiteral(new BigDecimal(10)));
+
+    checkImplies(node1, node2);
+    checkNotImplies(node2, node1);
+    checkImplies(node1, node3);
+    checkNotImplies(node3, node1);
+    checkImplies(node5, node2);
+    checkNotImplies(node2, node5);
+    checkNotImplies(node1, node5);
+    checkNotImplies(node1, node6);
+    checkNotImplies(node4, node6);
+    // TODO: Need to support Identity
+    //checkImplies(node1, node1);
+    //checkImplies(node3, node3);
+  }
+
+  @Test public void testSimpleEq() {
+    RexNode node1 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.EQUALS,
+                    b,
+                    rexBuilder.makeExactLiteral(new BigDecimal(30)));
+
+    RexNode node2 =
+            rexBuilder.makeCall(
+                    SqlStdOperatorTable.NOT_EQUALS,
+                    b,
+                    rexBuilder.makeExactLiteral(new BigDecimal(10)));
+
+    //Check Identity
+    checkImplies(node1, node1);
+    //TODO: Support Identity
+    // checkImplies(node2, node2);
+    checkImplies(node1, node2);
+    checkNotImplies(node2, node1);
+  }
+
+}

--- a/core/src/test/java/org/apache/calcite/test/RexImplicationCheckerTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RexImplicationCheckerTest.java
@@ -20,6 +20,7 @@ import org.apache.calcite.DataContext;
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptSchema;
+import org.apache.calcite.plan.RexImplicationChecker;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
@@ -35,11 +36,9 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.util.NlsString;
 
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-
-import plan.RexImplicationChecker;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -56,39 +55,39 @@ import java.util.Calendar;
 public class RexImplicationCheckerTest {
   //~ Instance fields --------------------------------------------------------
 
-  static RexBuilder rexBuilder = null;
-  static RexNode bl;
-  static RexNode i;
-  static RexNode dec;
-  static RexNode lg;
-  static RexNode sh;
-  static RexNode by;
-  static RexNode fl;
-  static RexNode dt;
-  static RexNode ch;
-  static RexNode ts;
-  static RexNode t;
+  private RexBuilder rexBuilder = null;
+  private RexNode bl;
+  private RexNode i;
+  private RexNode dec;
+  private RexNode lg;
+  private RexNode sh;
+  private RexNode by;
+  private RexNode fl;
+  private RexNode dt;
+  private RexNode ch;
+  private RexNode ts;
+  private RexNode t;
 
-  static RelDataType boolRelDataType;
-  static RelDataType intRelDataType;
-  static RelDataType decRelDataType;
-  static RelDataType longRelDataType;
-  static RelDataType shortDataType;
-  static RelDataType byteDataType;
-  static RelDataType floatDataType;
-  static RelDataType charDataType;
-  static RelDataType dateDataType;
-  static RelDataType timeStampDataType;
-  static RelDataType timeDataType;
-  static RelDataTypeFactory typeFactory;
-  static RexImplicationChecker checker;
-  static RelDataType rowType;
-  static RexExecutorImpl executor;
+  private RelDataType boolRelDataType;
+  private RelDataType intRelDataType;
+  private RelDataType decRelDataType;
+  private RelDataType longRelDataType;
+  private RelDataType shortDataType;
+  private RelDataType byteDataType;
+  private RelDataType floatDataType;
+  private RelDataType charDataType;
+  private RelDataType dateDataType;
+  private RelDataType timeStampDataType;
+  private RelDataType timeDataType;
+  private RelDataTypeFactory typeFactory;
+  private RexImplicationChecker checker;
+  private RelDataType rowType;
+  private RexExecutorImpl executor;
 
   //~ Methods ----------------------------------------------------------------
 
-  @BeforeClass
-  public static void setUp() {
+  @Before
+  public void setUp() {
     typeFactory = new JavaTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
     rexBuilder = new RexBuilder(typeFactory);
     boolRelDataType = typeFactory.createJavaType(Boolean.class);
@@ -104,52 +103,52 @@ public class RexImplicationCheckerTest {
     timeDataType = typeFactory.createJavaType(Time.class);
 
     bl = new RexInputRef(
-            0,
-            typeFactory.createTypeWithNullability(boolRelDataType, true));
+        0,
+        typeFactory.createTypeWithNullability(boolRelDataType, true));
     i = new RexInputRef(
-            1,
-            typeFactory.createTypeWithNullability(intRelDataType, true));
+        1,
+        typeFactory.createTypeWithNullability(intRelDataType, true));
     dec = new RexInputRef(
-            2,
-            typeFactory.createTypeWithNullability(decRelDataType, true));
+        2,
+        typeFactory.createTypeWithNullability(decRelDataType, true));
     lg = new RexInputRef(
-            3,
-            typeFactory.createTypeWithNullability(longRelDataType, true));
+        3,
+        typeFactory.createTypeWithNullability(longRelDataType, true));
     sh = new RexInputRef(
-            4,
-            typeFactory.createTypeWithNullability(shortDataType, true));
+        4,
+        typeFactory.createTypeWithNullability(shortDataType, true));
     by = new RexInputRef(
-            5,
-            typeFactory.createTypeWithNullability(byteDataType, true));
+        5,
+        typeFactory.createTypeWithNullability(byteDataType, true));
     fl = new RexInputRef(
-            6,
-            typeFactory.createTypeWithNullability(floatDataType, true));
+        6,
+        typeFactory.createTypeWithNullability(floatDataType, true));
     ch = new RexInputRef(
-            7,
-            typeFactory.createTypeWithNullability(charDataType, true));
+        7,
+        typeFactory.createTypeWithNullability(charDataType, true));
     dt = new RexInputRef(
-            8,
-            typeFactory.createTypeWithNullability(dateDataType, true));
+        8,
+        typeFactory.createTypeWithNullability(dateDataType, true));
     ts = new RexInputRef(
-            9,
-            typeFactory.createTypeWithNullability(timeStampDataType, true));
+        9,
+        typeFactory.createTypeWithNullability(timeStampDataType, true));
     t = new RexInputRef(
-            10,
-            typeFactory.createTypeWithNullability(timeDataType, true));
+        10,
+        typeFactory.createTypeWithNullability(timeDataType, true));
 
     rowType =  typeFactory.builder()
-            .add("bool", boolRelDataType)
-            .add("int", intRelDataType)
-            .add("dec", decRelDataType)
-            .add("long", longRelDataType)
-            .add("short", shortDataType)
-            .add("byte", byteDataType)
-            .add("float", floatDataType)
-            .add("char", charDataType)
-            .add("date", dateDataType)
-            .add("timestamp", timeStampDataType)
-            .add("time", timeDataType)
-            .build();
+        .add("bool", boolRelDataType)
+        .add("int", intRelDataType)
+        .add("dec", decRelDataType)
+        .add("long", longRelDataType)
+        .add("short", shortDataType)
+        .add("byte", byteDataType)
+        .add("float", floatDataType)
+        .add("char", charDataType)
+        .add("date", dateDataType)
+        .add("timestamp", timeStampDataType)
+        .add("time", timeDataType)
+        .build();
 
     Frameworks.withPrepare(
         new Frameworks.PrepareAction<Void>() {
@@ -158,7 +157,7 @@ public class RexImplicationCheckerTest {
                             SchemaPlus rootSchema,
                             CalciteServerStatement statement) {
             DataContext dataContext =
-                    Schemas.createDataContext(statement.getConnection());
+                Schemas.createDataContext(statement.getConnection());
             executor = new RexExecutorImpl(dataContext);
             return null;
           }
@@ -168,52 +167,52 @@ public class RexImplicationCheckerTest {
   }
 
   private void checkImplies(RexNode node1, RexNode node2) {
-    assertTrue(node1.toString() + " doesnot imply " + node2.toString() + " when it should.",
-            checker.implies(node1, node2));
+    assertTrue(node1.toString() + " doesnot imply " + node2.toString()
+        + " when it should.", checker.implies(node1, node2));
   }
 
   private void checkNotImplies(RexNode node1, RexNode node2) {
-    assertFalse(node1.toString() + " implies " + node2.toString() + " when it should not",
-            checker.implies(node1, node2));
+    assertFalse(node1.toString() + " implies " + node2.toString()
+        + " when it should not", checker.implies(node1, node2));
   }
 
   // Simple Tests for Operators
   @Test public void testSimpleGreaterCond() {
     RexNode node1 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.GREATER_THAN,
-                    i,
-                    rexBuilder.makeExactLiteral(new BigDecimal(10)));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN,
+            i,
+            rexBuilder.makeExactLiteral(new BigDecimal(10)));
 
     RexNode node2 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.GREATER_THAN,
-                    i,
-                    rexBuilder.makeExactLiteral(new BigDecimal(30)));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN,
+            i,
+            rexBuilder.makeExactLiteral(new BigDecimal(30)));
 
     RexNode node3 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
-                    i,
-                    rexBuilder.makeExactLiteral(new BigDecimal(30)));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+            i,
+            rexBuilder.makeExactLiteral(new BigDecimal(30)));
 
     RexNode node4 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
-                    i,
-                    rexBuilder.makeExactLiteral(new BigDecimal(10)));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+            i,
+            rexBuilder.makeExactLiteral(new BigDecimal(10)));
 
     RexNode node5 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.EQUALS,
-                    i,
-                    rexBuilder.makeExactLiteral(new BigDecimal(30)));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            i,
+            rexBuilder.makeExactLiteral(new BigDecimal(30)));
 
     RexNode node6 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.NOT_EQUALS,
-                    i,
-                    rexBuilder.makeExactLiteral(new BigDecimal(10)));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.NOT_EQUALS,
+            i,
+            rexBuilder.makeExactLiteral(new BigDecimal(10)));
 
     checkImplies(node2, node1);
     checkNotImplies(node1, node2);
@@ -230,40 +229,40 @@ public class RexImplicationCheckerTest {
 
   @Test public void testSimpleLesserCond() {
     RexNode node1 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.LESS_THAN,
-                    i,
-                    rexBuilder.makeExactLiteral(new BigDecimal(10)));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.LESS_THAN,
+            i,
+            rexBuilder.makeExactLiteral(new BigDecimal(10)));
 
     RexNode node2 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.LESS_THAN,
-                    i,
-                    rexBuilder.makeExactLiteral(new BigDecimal(30)));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.LESS_THAN,
+            i,
+            rexBuilder.makeExactLiteral(new BigDecimal(30)));
 
     RexNode node3 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
-                    i,
-                    rexBuilder.makeExactLiteral(new BigDecimal(30)));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
+            i,
+            rexBuilder.makeExactLiteral(new BigDecimal(30)));
 
     RexNode node4 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
-                    i,
-                    rexBuilder.makeExactLiteral(new BigDecimal(10)));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
+            i,
+            rexBuilder.makeExactLiteral(new BigDecimal(10)));
 
     RexNode node5 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.EQUALS,
-                    i,
-                    rexBuilder.makeExactLiteral(new BigDecimal(10)));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            i,
+            rexBuilder.makeExactLiteral(new BigDecimal(10)));
 
     RexNode node6 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.NOT_EQUALS,
-                    i,
-                    rexBuilder.makeExactLiteral(new BigDecimal(10)));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.NOT_EQUALS,
+            i,
+            rexBuilder.makeExactLiteral(new BigDecimal(10)));
 
     checkImplies(node1, node2);
     checkNotImplies(node2, node1);
@@ -281,16 +280,16 @@ public class RexImplicationCheckerTest {
 
   @Test public void testSimpleEq() {
     RexNode node1 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.EQUALS,
-                    i,
-                    rexBuilder.makeExactLiteral(new BigDecimal(30)));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            i,
+            rexBuilder.makeExactLiteral(new BigDecimal(30)));
 
     RexNode node2 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.NOT_EQUALS,
-                    i,
-                    rexBuilder.makeExactLiteral(new BigDecimal(10)));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.NOT_EQUALS,
+            i,
+            rexBuilder.makeExactLiteral(new BigDecimal(10)));
 
     //Check Identity
     checkImplies(node1, node1);
@@ -303,16 +302,16 @@ public class RexImplicationCheckerTest {
   // Simple Tests for DataTypes
   @Test public void testSimpleDec() {
     RexNode node1 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.LESS_THAN,
-                    dec,
-                    rexBuilder.makeApproxLiteral(new BigDecimal(30.9)));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.LESS_THAN,
+            dec,
+            rexBuilder.makeApproxLiteral(new BigDecimal(30.9)));
 
     RexNode node2 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.LESS_THAN,
-                    dec,
-                    rexBuilder.makeApproxLiteral(new BigDecimal(40.33)));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.LESS_THAN,
+            dec,
+            rexBuilder.makeApproxLiteral(new BigDecimal(40.33)));
 
     checkImplies(node1, node2);
     checkNotImplies(node2, node1);
@@ -320,16 +319,16 @@ public class RexImplicationCheckerTest {
 
   @Test public void testSimpleBoolean() {
     RexNode node1 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.EQUALS,
-                    bl,
-                    rexBuilder.makeLiteral(true));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            bl,
+            rexBuilder.makeLiteral(true));
 
     RexNode node2 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.EQUALS,
-                    bl,
-                    rexBuilder.makeLiteral(false));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            bl,
+            rexBuilder.makeLiteral(false));
 
     //TODO: Need to support false => true
     //checkImplies(node2, node1);
@@ -338,16 +337,16 @@ public class RexImplicationCheckerTest {
 
   @Test public void testSimpleLong() {
     RexNode node1 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
-                    lg,
-                    rexBuilder.makeLiteral(new Long(324324L), longRelDataType, true));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+            lg,
+            rexBuilder.makeLiteral(new Long(324324L), longRelDataType, true));
 
     RexNode node2 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.GREATER_THAN,
-                    lg,
-                    rexBuilder.makeLiteral(new Long(324325L), longRelDataType, true));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN,
+            lg,
+            rexBuilder.makeLiteral(new Long(324325L), longRelDataType, true));
 
     checkImplies(node2, node1);
     checkNotImplies(node1, node2);
@@ -355,16 +354,16 @@ public class RexImplicationCheckerTest {
 
   @Test public void testSimpleShort() {
     RexNode node1 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
-                    sh,
-                    rexBuilder.makeLiteral(new Short((short) 10), shortDataType, true));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+            sh,
+            rexBuilder.makeLiteral(new Short((short) 10), shortDataType, true));
 
     RexNode node2 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
-                    sh,
-                    rexBuilder.makeLiteral(new Short((short) 11), shortDataType, true));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+            sh,
+            rexBuilder.makeLiteral(new Short((short) 11), shortDataType, true));
 
     checkImplies(node2, node1);
     checkNotImplies(node1, node2);
@@ -372,16 +371,16 @@ public class RexImplicationCheckerTest {
 
   @Test public void testSimpleChar() {
     RexNode node1 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
-                    ch,
-                    rexBuilder.makeCharLiteral(new NlsString("b", null, SqlCollation.COERCIBLE)));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+            ch,
+            rexBuilder.makeCharLiteral(new NlsString("b", null, SqlCollation.COERCIBLE)));
 
     RexNode node2 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
-                    ch,
-                    rexBuilder.makeCharLiteral(new NlsString("a", null, SqlCollation.COERCIBLE)));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+            ch,
+            rexBuilder.makeCharLiteral(new NlsString("a", null, SqlCollation.COERCIBLE)));
 
     checkImplies(node1, node2);
     checkNotImplies(node2, node1);
@@ -389,16 +388,16 @@ public class RexImplicationCheckerTest {
 
   @Test public void testSimpleDate() {
     RexNode node1 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
-                    dt,
-                    rexBuilder.makeDateLiteral(Calendar.getInstance()));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+            dt,
+            rexBuilder.makeDateLiteral(Calendar.getInstance()));
 
     RexNode node2 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.EQUALS,
-                    dt,
-                    rexBuilder.makeDateLiteral(Calendar.getInstance()));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            dt,
+            rexBuilder.makeDateLiteral(Calendar.getInstance()));
 
     checkImplies(node2, node1);
     checkNotImplies(node1, node2);
@@ -407,19 +406,19 @@ public class RexImplicationCheckerTest {
   @Ignore("work in progress")
   @Test public void testSimpleTimeStamp() {
     RexNode node1 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
-                    ts,
-                    rexBuilder.makeTimestampLiteral(Calendar.getInstance(),
-                            timeStampDataType.getPrecision()));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
+            ts,
+            rexBuilder.makeTimestampLiteral(Calendar.getInstance(),
+                timeStampDataType.getPrecision()));
 
 
     RexNode node2 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
-                    ts,
-                    rexBuilder.makeTimestampLiteral(Calendar.getInstance(),
-                            timeStampDataType.getPrecision()));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
+            ts,
+            rexBuilder.makeTimestampLiteral(Calendar.getInstance(),
+                timeStampDataType.getPrecision()));
 
     checkImplies(node1, node2);
     checkNotImplies(node2, node1);
@@ -428,19 +427,19 @@ public class RexImplicationCheckerTest {
   @Ignore("work in progress")
   @Test public void testSimpleTime() {
     RexNode node1 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
-                    t,
-                    rexBuilder.makeTimeLiteral(Calendar.getInstance(),
-                            timeDataType.getPrecision()));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
+            t,
+            rexBuilder.makeTimeLiteral(Calendar.getInstance(),
+                timeDataType.getPrecision()));
 
 
     RexNode node2 =
-            rexBuilder.makeCall(
-                    SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
-                    t,
-                    rexBuilder.makeTimestampLiteral(Calendar.getInstance(),
-                            timeDataType.getPrecision()));
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
+            t,
+            rexBuilder.makeTimestampLiteral(Calendar.getInstance(),
+                timeDataType.getPrecision()));
 
     checkImplies(node1, node2);
     checkNotImplies(node2, node1);


### PR DESCRIPTION
This is first submission for CALCITE-786. As seen in UTs added it can handle many interesting cases now. There are still many cases which needs to be handled though and we will get to that soon in future. Submission introduces basic structure now which will enable us to extend it in future:
1. New Substitution visitor (MaterializedSubstitutionVisitor) which introduces rules for rewriting queries in non-trivial cases. Currently one rule is introduced and it can be extended by adding more rules as and when required.
2. RexImplicationChecker. This checks if one condition implies another and is the basis of the algorithm. This now handles few kind of operators and datatypes. It can be easily extended for more.