### PR TITLE
[CALCITE-787] Fixing wrong assignment of star table to Materialized View

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptMaterialization.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptMaterialization.java
@@ -191,7 +191,8 @@ public class RelOptMaterialization {
           }
         });
     if (rel2 == rel) {
-      return rel;
+      // No rewrite happened.
+      return null;
     }
     final Program program = Programs.hep(
         ImmutableList.of(ProjectFilterTransposeRule.INSTANCE,

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
@@ -389,7 +389,7 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
     // the query in terms of the star table.
     if (materialization.starTable != null) {
       RelNode newRoot = RelOptMaterialization.tryUseStar(
-              root, materialization.starRelOptTable);
+          root, materialization.starRelOptTable);
       if (newRoot != null) {
         root = newRoot;
       }

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
@@ -388,8 +388,11 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
     // First, if the materialization is in terms of a star table, rewrite
     // the query in terms of the star table.
     if (materialization.starTable != null) {
-      root = RelOptMaterialization.tryUseStar(
-          root, materialization.starRelOptTable);
+      RelNode newRoot = RelOptMaterialization.tryUseStar(
+              root, materialization.starRelOptTable);
+      if (newRoot != null) {
+        root = newRoot;
+      }
     }
 
     // Push filters to the bottom, and combine projects on top.

--- a/core/src/test/java/org/apache/calcite/test/LatticeTest.java
+++ b/core/src/test/java/org/apache/calcite/test/LatticeTest.java
@@ -622,6 +622,61 @@ public class LatticeTest {
                 counter));
     assertThat(counter.intValue(), equalTo(1));
   }
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-787">[CALCITE-787]
+   * Wrong assignment of star table to Materialized views</a> */
+  @Test public void testOneLatticeOneMV() {
+    final AtomicInteger counter = new AtomicInteger();
+    final Class<JdbcTest.EmpDeptTableFactory> clazz =
+            JdbcTest.EmpDeptTableFactory.class;
+
+    final String mv = "       materializations: [\n"
+            + "         {\n"
+            + "           table: \"m0\",\n"
+            + "           view: \"m0v\",\n"
+            + "           sql: \"select * from \\\"foodmart\\\".\\\"sales_fact_1997\\\" where \\\"product_id\\\" = 10\" "
+            + "         }\n"
+            + "       ]\n";
+
+    final String model =
+            ""
+                    + "{\n"
+                    + "  version: '1.0',\n"
+                    + "   schemas: [\n"
+                    + JdbcTest.FOODMART_SCHEMA
+                    + ",\n"
+                    + "     {\n"
+                    + "       name: 'adhoc',\n"
+                    + "       tables: [\n"
+                    + "         {\n"
+                    + "           name: 'EMPLOYEES',\n"
+                    + "           type: 'custom',\n"
+                    + "           factory: '"
+                    + clazz.getName()
+                    + "',\n"
+                    + "           operand: {'foo': true, 'bar': 345}\n"
+                    + "         }\n"
+                    + "       ],\n"
+                    + "       lattices: " + "[" + INVENTORY_LATTICE
+                    + "       ]\n"
+                    + "     },\n"
+                    + "     {\n"
+                    + "       name: 'mat',\n"
+                    + mv
+                    + "     }\n"
+                    + "   ]\n"
+                    + "}";
+
+    CalciteAssert.model(model)
+            .withDefaultSchema("foodmart")
+            .query("select * from \"foodmart\".\"sales_fact_1997\" where \"product_id\" = 10")
+            .enableMaterializations(true)
+            .substitutionMatches(
+                    CalciteAssert.checkRel(
+                            "EnumerableTableScan(table=[[mat, m0]])\n",
+                            counter));
+    assertThat(counter.intValue(), equalTo(1));
+  }
 
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-760">[CALCITE-760]

--- a/core/src/test/java/org/apache/calcite/test/LatticeTest.java
+++ b/core/src/test/java/org/apache/calcite/test/LatticeTest.java
@@ -628,53 +628,53 @@ public class LatticeTest {
   @Test public void testOneLatticeOneMV() {
     final AtomicInteger counter = new AtomicInteger();
     final Class<JdbcTest.EmpDeptTableFactory> clazz =
-            JdbcTest.EmpDeptTableFactory.class;
+        JdbcTest.EmpDeptTableFactory.class;
 
     final String mv = "       materializations: [\n"
-            + "         {\n"
-            + "           table: \"m0\",\n"
-            + "           view: \"m0v\",\n"
-            + "           sql: \"select * from \\\"foodmart\\\".\\\"sales_fact_1997\\\" where \\\"product_id\\\" = 10\" "
-            + "         }\n"
-            + "       ]\n";
+        + "         {\n"
+        + "           table: \"m0\",\n"
+        + "           view: \"m0v\",\n"
+        + "           sql: \"select * from \\\"foodmart\\\".\\\"sales_fact_1997\\\" "
+        + "where \\\"product_id\\\" = 10\" "
+        + "         }\n"
+        + "       ]\n";
 
-    final String model =
-            ""
-                    + "{\n"
-                    + "  version: '1.0',\n"
-                    + "   schemas: [\n"
-                    + JdbcTest.FOODMART_SCHEMA
-                    + ",\n"
-                    + "     {\n"
-                    + "       name: 'adhoc',\n"
-                    + "       tables: [\n"
-                    + "         {\n"
-                    + "           name: 'EMPLOYEES',\n"
-                    + "           type: 'custom',\n"
-                    + "           factory: '"
-                    + clazz.getName()
-                    + "',\n"
-                    + "           operand: {'foo': true, 'bar': 345}\n"
-                    + "         }\n"
-                    + "       ],\n"
-                    + "       lattices: " + "[" + INVENTORY_LATTICE
-                    + "       ]\n"
-                    + "     },\n"
-                    + "     {\n"
-                    + "       name: 'mat',\n"
-                    + mv
-                    + "     }\n"
-                    + "   ]\n"
-                    + "}";
+    final String model = ""
+        + "{\n"
+        + "  version: '1.0',\n"
+        + "   schemas: [\n"
+        + JdbcTest.FOODMART_SCHEMA
+        + ",\n"
+        + "     {\n"
+        + "       name: 'adhoc',\n"
+        + "       tables: [\n"
+        + "         {\n"
+        + "           name: 'EMPLOYEES',\n"
+        + "           type: 'custom',\n"
+        + "           factory: '"
+        + clazz.getName()
+        + "',\n"
+        + "           operand: {'foo': true, 'bar': 345}\n"
+        + "         }\n"
+        + "       ],\n"
+        + "       lattices: " + "[" + INVENTORY_LATTICE
+        + "       ]\n"
+        + "     },\n"
+        + "     {\n"
+        + "       name: 'mat',\n"
+        + mv
+        + "     }\n"
+        + "   ]\n"
+        + "}";
 
     CalciteAssert.model(model)
-            .withDefaultSchema("foodmart")
-            .query("select * from \"foodmart\".\"sales_fact_1997\" where \"product_id\" = 10")
-            .enableMaterializations(true)
-            .substitutionMatches(
-                    CalciteAssert.checkRel(
-                            "EnumerableTableScan(table=[[mat, m0]])\n",
-                            counter));
+        .withDefaultSchema("foodmart")
+        .query("select * from \"foodmart\".\"sales_fact_1997\" where \"product_id\" = 10")
+        .enableMaterializations(true)
+        .substitutionMatches(
+            CalciteAssert.checkRel(
+                "EnumerableTableScan(table=[[mat, m0]])\n",
+                counter));
     assertThat(counter.intValue(), equalTo(1));
   }
 


### PR DESCRIPTION
CalciteMaterializer tries to rewrite query relnode of a MV with the star table found (the first one that fits). Utility function used is RelOptMaterialization::tryUseStar. Utility function should return null when it cannot rewrite relnode using star table, but instead it is returning the same relnode back. This is causing MV being assigned star table even when it is not required. The problem with this is if star table is not null it is assumed to be tile (when it is not) and VolcanoPlanner::useMaterialization is not invoked for it.   

RelOptMaterialization::tryUseStar is used in 3 places. Couple of them expect null to be returned when star table cannot be used. One of them i.e., VolcannoPlanner::substitute is not expecting it, so rewriting it.

Added a Testpoint which reproduces the issue. It does not allow rewrite due to Materialized View as it's star table is not null.