### PR TITLE
CALCITE-805: Add support for using an alternative grammar specificati…

### DIFF
--- a/core/src/main/codegen/config.fmpp
+++ b/core/src/main/codegen/config.fmpp
@@ -74,6 +74,8 @@ data: {
     ]
 
     includeCompoundIdentifier: true
+    includeBraces: true
+    includeAdditionalDeclarations: false    
   }
 }
 

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -5382,12 +5382,16 @@ String CommonNonReservedKeyWord() :
 {
     < LPAREN: "(">
     | < RPAREN: ")">
+    <#if parser.includeBraces >
     | < LBRACE_D: "{" (" ")* ["d","D"] >
     | < LBRACE_T: "{" (" ")* ["t","T"] >
     | < LBRACE_TS: "{" (" ")* ["t","T"] ["s","S"] >
     | < LBRACE_FN: "{" (" ")* ["f","F"] ["n","N"] >
     | < LBRACE: "{" >
     | < RBRACE: "}" >
+    <#else>
+      <#include "/@includes/braces.ftl" />
+    </#if>
     | < LBRACKET: "[" >
     | < RBRACKET: "]" >
     | < SEMICOLON: ";" >
@@ -5432,6 +5436,10 @@ TOKEN_MGR_DECLS : {
     void popState() {
       SwitchTo(lexicalStateStack.remove(lexicalStateStack.size() - 1));
     }
+
+    <#if parser.includeAdditionalDeclarations>
+      <#include "/@includes/tokenManagerDeclarations.ftl" />
+    </#if>
 }
 
 /*


### PR DESCRIPTION
…on for left and right curly braces. Additionally, add support for including addition token manager declarations.