### PR TITLE
Lazily create exception only when it needs to be thrown

### DIFF
--- a/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
@@ -1250,7 +1250,7 @@ public class CalcitePrepareImpl implements CalcitePrepare {
       if (i >= 0) {
         return values.get(i);
       }
-      throw ion = nullException("unknown parameter " + param);
+      throw new RuntimeException("unknown parameter " + param);
     }
   }
 }

--- a/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
@@ -560,7 +560,7 @@ public class CalcitePrepareImpl implements CalcitePrepare {
     if (plannerFactories.isEmpty()) {
       throw new AssertionError("no planner factories");
     }
-    RuntimeException exception = new RuntimeException();
+    RuntimeException exception = null;
     for (Function1<Context, RelOptPlanner> plannerFactory : plannerFactories) {
       final RelOptPlanner planner = plannerFactory.apply(context);
       if (planner == null) {
@@ -573,7 +573,11 @@ public class CalcitePrepareImpl implements CalcitePrepare {
         exception = e;
       }
     }
-    throw exception;
+    if (exception == null) {
+      throw new RuntimeException();
+    } else {
+      throw exception;
+    }
   }
 
   /** Quickly prepares a simple SQL statement, circumventing the usual

--- a/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
@@ -560,7 +560,7 @@ public class CalcitePrepareImpl implements CalcitePrepare {
     if (plannerFactories.isEmpty()) {
       throw new AssertionError("no planner factories");
     }
-    RuntimeException exception = null;
+    RuntimeException exception = Util.FoundOne.NULL;
     for (Function1<Context, RelOptPlanner> plannerFactory : plannerFactories) {
       final RelOptPlanner planner = plannerFactory.apply(context);
       if (planner == null) {
@@ -573,11 +573,7 @@ public class CalcitePrepareImpl implements CalcitePrepare {
         exception = e;
       }
     }
-    if (exception == null) {
-      throw new RuntimeException();
-    } else {
-      throw exception;
-    }
+    throw exception;
   }
 
   /** Quickly prepares a simple SQL statement, circumventing the usual
@@ -1254,7 +1250,7 @@ public class CalcitePrepareImpl implements CalcitePrepare {
       if (i >= 0) {
         return values.get(i);
       }
-      throw new RuntimeException("unknown parameter " + param);
+      throw ion = nullException("unknown parameter " + param);
     }
   }
 }


### PR DESCRIPTION
Exceptions are expensive to create, so don't create a RuntimeException() unless we are actually going to throw something.