### PR TITLE
[CALCITE-823] Add support for RESET option statements

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -2830,32 +2830,48 @@ SqlCall SequenceExpression() :
 }
 
 /**
- * Parses an expression for setting a option in SQL, such as QUOTED_IDENTIFIERS,
+ * Parses an expression for setting or resetting an option in SQL, such as QUOTED_IDENTIFIERS,
  * or explain plan level (physical/logical).
  */
 SqlSetOption SqlSetOption() :
 {
-    SqlParserPos pos;
-    String scope;
-    String name;
+    SqlParserPos pos = null;
+    String scope = null;
+    SqlNode name;
     SqlNode val = null;
-    String keyword;
 }
 {
-    <ALTER> { pos = getPos(); }
-    scope = Scope()
-    <SET>
-    name = Identifier()
-    <EQ>
     (
-        val = Literal()
-    |
-        val = SimpleIdentifier()
-    |
-        <ON> {
-            // OFF is handled by SimpleIdentifier, ON handled here.
-            val = new SqlIdentifier(token.image.toUpperCase(), getPos());
+        <ALTER> { pos = getPos(); }
+        scope = Scope()
+    )?
+    (
+        <SET> {
+            pos = pos == null ? getPos() : pos;
         }
+        name = CompoundIdentifier()
+        <EQ>
+        (
+            val = Literal()
+        |
+            val = SimpleIdentifier()
+        |
+            <ON> {
+                // OFF is handled by SimpleIdentifier, ON handled here.
+                val = new SqlIdentifier(token.image.toUpperCase(), getPos());
+            }
+        )
+    |
+        <RESET> {
+            pos = pos == null ? getPos() : pos;
+        }
+        (
+            name = CompoundIdentifier()
+            |
+            <ALL> {
+                name = new SqlIdentifier(token.image.toUpperCase(), getPos());
+            }
+        )
     )
     {
         return new SqlSetOption(pos.plus(getPos()), scope, name, val);
@@ -4923,6 +4939,7 @@ SqlPostfixOperator PostfixRowOperator() :
     | < RELATIVE: "RELATIVE" >
     | < RELEASE: "RELEASE" >
     | < REPEATABLE: "REPEATABLE" >
+    | < RESET: "RESET" >
     | < RESTART: "RESTART" >
     | < RESTRICT: "RESTRICT" >
     | < RESULT: "RESULT" >

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -2837,7 +2837,7 @@ SqlSetOption SqlSetOption() :
 {
     SqlParserPos pos = null;
     String scope = null;
-    SqlNode name;
+    SqlIdentifier name;
     SqlNode val = null;
 }
 {

--- a/core/src/main/java/org/apache/calcite/sql/SqlSetOption.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSetOption.java
@@ -57,7 +57,7 @@ public class SqlSetOption extends SqlCall {
 
   /** Name of the option as a {@link org.apache.calcite.sql.SqlIdentifier}
    *  with one or more parts.*/
-  SqlNode name;
+  SqlIdentifier name;
 
   /** Value of the option. May be a {@link org.apache.calcite.sql.SqlLiteral} or
    * a {@link org.apache.calcite.sql.SqlIdentifier} with one
@@ -69,11 +69,12 @@ public class SqlSetOption extends SqlCall {
    * Creates a node.
    *
    * @param pos Parser position, must not be null.
-   * @param scope Scope (generally "SYSTEM" or "SESSION")
-   * @param name Name of option, as an identifier.
-   * @param value Value of option, as an identifier or literal.
+   * @param scope Scope (generally "SYSTEM" or "SESSION"), may be null.
+   * @param name Name of option, as an identifier, must not be null.
+   * @param value Value of option, as an identifier or literal, may be null.
+   *              If null, assume RESET command, else assume SET command.
    */
-  public SqlSetOption(SqlParserPos pos, String scope, SqlNode name,
+  public SqlSetOption(SqlParserPos pos, String scope, SqlIdentifier name,
       SqlNode value) {
     super(pos);
     this.scope = scope;
@@ -107,10 +108,12 @@ public class SqlSetOption extends SqlCall {
     case 0:
       if (operand != null) {
         scope = ((SqlIdentifier) operand).getSimple();
+      } else {
+        scope = null;
       }
       break;
     case 1:
-      name = operand;
+      name = (SqlIdentifier) operand;
       break;
     case 2:
       value = operand;
@@ -146,11 +149,11 @@ public class SqlSetOption extends SqlCall {
     validator.validate(value);
   }
 
-  public SqlNode getName() {
+  public SqlIdentifier getName() {
     return name;
   }
 
-  public void setName(SqlNode name) {
+  public void setName(SqlIdentifier name) {
     this.name = name;
   }
 

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -5749,8 +5749,9 @@ public class SqlParserTest {
         SqlParser.create("alter system set schema = true").parseStmt();
     SqlSetOption opt = (SqlSetOption) node;
     assertThat(opt.getScope(), equalTo("SYSTEM"));
-    assertThat(opt.getName(), equalTo("SCHEMA"));
     SqlPrettyWriter writer = new SqlPrettyWriter(SqlDialect.CALCITE);
+    assertThat(writer.format(opt.getName()), equalTo("\"SCHEMA\""));
+    writer = new SqlPrettyWriter(SqlDialect.CALCITE);
     assertThat(writer.format(opt.getValue()), equalTo("TRUE"));
     writer = new SqlPrettyWriter(SqlDialect.CALCITE);
     assertThat(writer.format(opt),
@@ -5768,6 +5769,33 @@ public class SqlParserTest {
         "ALTER SYSTEM SET `ONOFF` = `OFF`");
     check("alter system set baz = foo",
         "ALTER SYSTEM SET `BAZ` = `FOO`");
+
+
+    check("alter system set \"a\".\"number\" = 1",
+      "ALTER SYSTEM SET `a`.`number` = 1");
+    check("set approx = -12.3450",
+      "SET `APPROX` = -12.3450");
+
+    node = SqlParser.create("reset schema").parseStmt();
+    opt = (SqlSetOption) node;
+    assertThat(opt.getScope(), equalTo(null));
+    writer = new SqlPrettyWriter(SqlDialect.CALCITE);
+    assertThat(writer.format(opt.getName()), equalTo("\"SCHEMA\""));
+    assertThat(opt.getValue(), equalTo(null));
+    writer = new SqlPrettyWriter(SqlDialect.CALCITE);
+    assertThat(writer.format(opt),
+        equalTo("RESET \"SCHEMA\""));
+
+    check("alter system RESET flag",
+        "ALTER SYSTEM RESET `FLAG`");
+    check("reset onOff",
+        "RESET `ONOFF`");
+    check("reset \"this\".\"is\".\"sparta\"",
+        "RESET `this`.`is`.`sparta`");
+    check("alter system reset all",
+        "ALTER SYSTEM RESET `ALL`");
+    check("reset all",
+        "RESET `ALL`");
 
     // expressions not allowed
     checkFails("alter system set aString = 'abc' ^||^ 'def' ",

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -40,7 +40,11 @@ statement:
   |   query
 
 setStatement:
-      ALTER ( SYSTEM | SESSION ) SET identifier = expression
+      [ ALTER ( SYSTEM | SESSION ) ]
+      {
+          SET assign
+      |   RESET { identifier | ALL }
+      }
 
 explain:
       EXPLAIN PLAN


### PR DESCRIPTION
+ Parser support for statements like:
  ALTER scope RESET `option`.`name`;
  (reset option, multi-part identifier)

  ALTER scope RESET ALL;
  (reset all options)

  SET `option.name` = 1;
  (optional 'ALTER scope')

+ This is a breaking change in SetSqlOption API:
  #getName returns a multi-part SqlIdentifier
  #setName expects a SqlNode rather than a String

+ Added unit tests in SqlParseTest#testSqlOptions