### PR TITLE
[Linq4j] Implement the "todo" features in EnumerableDefaults

### DIFF
--- a/core/src/main/java/org/apache/calcite/prepare/QueryableRelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/prepare/QueryableRelBuilder.java
@@ -315,11 +315,11 @@ class QueryableRelBuilder<T> implements QueryableFactory<T> {
     throw new UnsupportedOperationException();
   }
 
-  public <TKey, TResult> Queryable<Grouping<TKey, TResult>> groupByK(
+  public <TKey, TResult> Queryable<TResult> groupByK(
       Queryable<T> source,
       FunctionExpression<Function1<T, TKey>> keySelector,
       FunctionExpression<Function2<TKey, Enumerable<T>, TResult>>
-          elementSelector) {
+          resultSelector) {
     throw new UnsupportedOperationException();
   }
 

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/DefaultEnumerable.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/DefaultEnumerable.java
@@ -198,7 +198,7 @@ public abstract class DefaultEnumerable<T> implements OrderedEnumerable<T> {
     return EnumerableDefaults.defaultIfEmpty(getThis());
   }
 
-  public T defaultIfEmpty(T value) {
+  public Enumerable<T>  defaultIfEmpty(T value) {
     return EnumerableDefaults.defaultIfEmpty(getThis(), value);
   }
 

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/DefaultEnumerable.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/DefaultEnumerable.java
@@ -258,24 +258,25 @@ public abstract class DefaultEnumerable<T> implements OrderedEnumerable<T> {
     return EnumerableDefaults.groupBy(getThis(), keySelector, elementSelector);
   }
 
-  public <TKey, TResult> Enumerable<Grouping<TKey, TResult>> groupBy(
-      Function1<T, TKey> keySelector,
-      Function2<TKey, Enumerable<T>, TResult> elementSelector) {
-    return EnumerableDefaults.groupBy(getThis(), keySelector, elementSelector);
-  }
-
   public <TKey, TElement> Enumerable<Grouping<TKey, TElement>> groupBy(
       Function1<T, TKey> keySelector, Function1<T, TElement> elementSelector,
-      EqualityComparer comparer) {
-    return EnumerableDefaults.groupBy(getThis(), keySelector, elementSelector);
+      EqualityComparer<TKey> comparer) {
+    return EnumerableDefaults.groupBy(getThis(), keySelector, elementSelector,
+        comparer);
   }
 
   public <TKey, TResult> Enumerable<TResult> groupBy(
       Function1<T, TKey> keySelector,
       Function2<TKey, Enumerable<T>, TResult> elementSelector,
-      EqualityComparer comparer) {
+      EqualityComparer<TKey> comparer) {
     return EnumerableDefaults.groupBy(getThis(), keySelector, elementSelector,
         comparer);
+  }
+
+  public <TKey, TResult> Enumerable<TResult> groupBy(
+      Function1<T, TKey> keySelector,
+      Function2<TKey, Enumerable<T>, TResult> resultSelector) {
+    return EnumerableDefaults.groupBy(getThis(), keySelector, resultSelector);
   }
 
   public <TKey, TElement, TResult> Enumerable<TResult> groupBy(

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/DefaultQueryable.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/DefaultQueryable.java
@@ -247,13 +247,6 @@ abstract class DefaultQueryable<T> extends DefaultEnumerable<T>
     return factory.groupBy(getThis(), keySelector, elementSelector);
   }
 
-  public <TKey, TResult> Queryable<Grouping<TKey, TResult>> groupByK(
-      FunctionExpression<Function1<T, TKey>> keySelector,
-      FunctionExpression<Function2<TKey, Enumerable<T>, TResult>>
-          elementSelector) {
-    return factory.groupByK(getThis(), keySelector, elementSelector);
-  }
-
   public <TKey, TElement> Queryable<Grouping<TKey, TElement>> groupBy(
       FunctionExpression<Function1<T, TKey>> keySelector,
       FunctionExpression<Function1<T, TElement>> elementSelector,
@@ -263,17 +256,21 @@ abstract class DefaultQueryable<T> extends DefaultEnumerable<T>
 
   public <TKey, TResult> Queryable<TResult> groupByK(
       FunctionExpression<Function1<T, TKey>> keySelector,
-      FunctionExpression<Function2<TKey, Enumerable<T>, TResult>>
-        elementSelector,
+      FunctionExpression<Function2<TKey, Enumerable<T>, TResult>> resultSelector) {
+    return factory.groupByK(getThis(), keySelector, resultSelector);
+  }
+
+  public <TKey, TResult> Queryable<TResult> groupByK(
+      FunctionExpression<Function1<T, TKey>> keySelector,
+      FunctionExpression<Function2<TKey, Enumerable<T>, TResult>> resultSelector,
       EqualityComparer<TKey> comparer) {
-    return factory.groupByK(getThis(), keySelector, elementSelector, comparer);
+    return factory.groupByK(getThis(), keySelector, resultSelector, comparer);
   }
 
   public <TKey, TElement, TResult> Queryable<TResult> groupBy(
       FunctionExpression<Function1<T, TKey>> keySelector,
       FunctionExpression<Function1<T, TElement>> elementSelector,
-      FunctionExpression<Function2<TKey, Enumerable<TElement>, TResult>>
-        resultSelector) {
+      FunctionExpression<Function2<TKey, Enumerable<TElement>, TResult>> resultSelector) {
     return factory.groupBy(getThis(), keySelector, elementSelector,
         resultSelector);
   }
@@ -281,8 +278,7 @@ abstract class DefaultQueryable<T> extends DefaultEnumerable<T>
   public <TKey, TElement, TResult> Queryable<TResult> groupBy(
       FunctionExpression<Function1<T, TKey>> keySelector,
       FunctionExpression<Function1<T, TElement>> elementSelector,
-      FunctionExpression<Function2<TKey, Enumerable<TElement>, TResult>>
-        resultSelector,
+      FunctionExpression<Function2<TKey, Enumerable<TElement>, TResult>> resultSelector,
       EqualityComparer<TKey> comparer) {
     return factory.groupBy(getThis(), keySelector, elementSelector,
         resultSelector, comparer);
@@ -292,8 +288,7 @@ abstract class DefaultQueryable<T> extends DefaultEnumerable<T>
       Enumerable<TInner> inner,
       FunctionExpression<Function1<T, TKey>> outerKeySelector,
       FunctionExpression<Function1<TInner, TKey>> innerKeySelector,
-      FunctionExpression<Function2<T, Enumerable<TInner>, TResult>>
-        resultSelector) {
+      FunctionExpression<Function2<T, Enumerable<TInner>, TResult>> resultSelector) {
     return factory.groupJoin(getThis(), inner, outerKeySelector,
         innerKeySelector, resultSelector);
   }
@@ -302,8 +297,7 @@ abstract class DefaultQueryable<T> extends DefaultEnumerable<T>
       Enumerable<TInner> inner,
       FunctionExpression<Function1<T, TKey>> outerKeySelector,
       FunctionExpression<Function1<TInner, TKey>> innerKeySelector,
-      FunctionExpression<Function2<T, Enumerable<TInner>, TResult>>
-        resultSelector,
+      FunctionExpression<Function2<T, Enumerable<TInner>, TResult>> resultSelector,
       EqualityComparer<TKey> comparer) {
     return factory.groupJoin(getThis(), inner, outerKeySelector,
         innerKeySelector, resultSelector, comparer);

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableDefaults.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableDefaults.java
@@ -2847,9 +2847,35 @@ public abstract class EnumerableDefaults {
    * results.
    */
   public static <T0, T1, TResult> Enumerable<TResult> zip(
-      Enumerable<T0> source0, Enumerable<T1> source1,
-      Function2<T0, T1, TResult> resultSelector) {
-    throw Extensions.todo();
+      final Enumerable<T0> first, final Enumerable<T1> second,
+      final Function2<T0, T1, TResult> resultSelector) {
+    return new AbstractEnumerable<TResult>() {
+      @Override
+      public Enumerator<TResult> enumerator() {
+        return new Enumerator<TResult>() {
+          final Enumerator<T0> e1 = first.enumerator();
+          final Enumerator<T1> e2 = second.enumerator();
+          @Override
+          public TResult current() {
+            return resultSelector.apply(e1.current(), e2.current());
+          }
+          @Override
+          public boolean moveNext() {
+            return e1.moveNext() && e2.moveNext();
+          }
+          @Override
+          public void reset() {
+            e1.reset();
+            e2.reset();
+          }
+          @Override
+          public void close() {
+            e1.close();
+            e2.close();
+          }
+        };
+      }
+    };
   }
 
   public static <T> OrderedQueryable<T> asOrderedQueryable(

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableDefaults.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableDefaults.java
@@ -682,18 +682,7 @@ public abstract class EnumerableDefaults {
   public static <TSource, TKey, TElement> Enumerable<Grouping<TKey, TElement>>
   groupBy(Enumerable<TSource> enumerable, Function1<TSource, TKey> keySelector,
       Function1<TSource, TElement> elementSelector) {
-    throw Extensions.todo();
-  }
-
-  /**
-   * Groups the elements of a sequence according to a
-   * specified key selector function and creates a result value from
-   * each group and its key.
-   */
-  public static <TSource, TKey, TResult> Enumerable<Grouping<TKey, TResult>>
-  groupBy(Enumerable<TSource> enumerable, Function1<TSource, TKey> keySelector,
-      Function2<TKey, Enumerable<TSource>, TResult> elementSelector) {
-    throw Extensions.todo();
+    return enumerable.toLookup(keySelector, elementSelector);
   }
 
   /**
@@ -706,7 +695,24 @@ public abstract class EnumerableDefaults {
   groupBy(Enumerable<TSource> enumerable, Function1<TSource, TKey> keySelector,
       Function1<TSource, TElement> elementSelector,
       EqualityComparer<TKey> comparer) {
-    throw Extensions.todo();
+    return enumerable.toLookup(keySelector, elementSelector, comparer);
+  }
+
+  /**
+   * Groups the elements of a sequence according to a
+   * specified key selector function and creates a result value from
+   * each group and its key.
+   */
+  public static <TSource, TKey, TResult> Enumerable<TResult>
+  groupBy(Enumerable<TSource> enumerable, Function1<TSource, TKey> keySelector,
+      final Function2<TKey, Enumerable<TSource>, TResult> resultSelector) {
+    return enumerable.toLookup(keySelector)
+        .select(new Function1<Grouping<TKey, TSource>, TResult>() {
+          @Override
+          public TResult apply(Grouping<TKey, TSource> group) {
+            return resultSelector.apply(group.getKey(), group);
+          }
+        });
   }
 
   /**
@@ -715,11 +721,17 @@ public abstract class EnumerableDefaults {
    * each group and its key. The keys are compared by using a
    * specified comparer.
    */
-  public static <TSource, TKey, TResult> Enumerable<TResult> groupBy(
-      Enumerable<TSource> enumerable, Function1<TSource, TKey> keySelector,
-      Function2<TKey, Enumerable<TSource>, TResult> elementSelector,
-      EqualityComparer comparer) {
-    throw Extensions.todo();
+  public static <TSource, TKey, TResult> Enumerable<TResult>
+  groupBy(Enumerable<TSource> enumerable, Function1<TSource, TKey> keySelector,
+      final Function2<TKey, Enumerable<TSource>, TResult> resultSelector,
+      EqualityComparer<TKey> comparer) {
+    return enumerable.toLookup(keySelector, comparer)
+        .select(new Function1<Grouping<TKey, TSource>, TResult>() {
+          @Override
+          public TResult apply(Grouping<TKey, TSource> group) {
+            return resultSelector.apply(group.getKey(), group);
+          }
+        });
   }
 
   /**
@@ -731,8 +743,14 @@ public abstract class EnumerableDefaults {
   public static <TSource, TKey, TElement, TResult> Enumerable<TResult> groupBy(
       Enumerable<TSource> enumerable, Function1<TSource, TKey> keySelector,
       Function1<TSource, TElement> elementSelector,
-      Function2<TKey, Enumerable<TElement>, TResult> resultSelector) {
-    throw Extensions.todo();
+      final Function2<TKey, Enumerable<TElement>, TResult> resultSelector) {
+    return enumerable.toLookup(keySelector, elementSelector)
+        .select(new Function1<Grouping<TKey, TElement>, TResult>() {
+          @Override
+          public TResult apply(Grouping<TKey, TElement> group) {
+            return resultSelector.apply(group.getKey(), group);
+          }
+        });
   }
 
   /**
@@ -745,9 +763,15 @@ public abstract class EnumerableDefaults {
   public static <TSource, TKey, TElement, TResult> Enumerable<TResult> groupBy(
       Enumerable<TSource> enumerable, Function1<TSource, TKey> keySelector,
       Function1<TSource, TElement> elementSelector,
-      Function2<TKey, Enumerable<TElement>, TResult> resultSelector,
+      final Function2<TKey, Enumerable<TElement>, TResult> resultSelector,
       EqualityComparer<TKey> comparer) {
-    throw Extensions.todo();
+    return enumerable.toLookup(keySelector, elementSelector, comparer)
+        .select(new Function1<Grouping<TKey, TElement>, TResult>() {
+          @Override
+          public TResult apply(Grouping<TKey, TElement> group) {
+            return resultSelector.apply(group.getKey(), group);
+          }
+        });
   }
 
   /**

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableDefaults.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableDefaults.java
@@ -502,7 +502,7 @@ public abstract class EnumerableDefaults {
         if (index == 0) {
           return os.current();
         }
-        index --;
+        index--;
       }
     } finally {
       os.close();
@@ -535,7 +535,7 @@ public abstract class EnumerableDefaults {
             if (index == 0) {
               return os.current();
             }
-            index --;
+            index--;
           }
         } finally {
           os.close();
@@ -831,13 +831,13 @@ public abstract class EnumerableDefaults {
       EqualityComparer<TKey> comparer) {
     return groupBy_(
         new WrapMap<TKey, TAccumulate>(
-            new Function0<Map<Wrapped<TKey>, TAccumulate>>() {
-              @Override
-              public Map<Wrapped<TKey>, TAccumulate> apply() {
-                return new HashMap<Wrapped<TKey>, TAccumulate>();
-              }
-            },
-            comparer),
+          new Function0<Map<Wrapped<TKey>, TAccumulate>>() {
+            @Override
+            public Map<Wrapped<TKey>, TAccumulate> apply() {
+              return new HashMap<Wrapped<TKey>, TAccumulate>();
+            }
+          },
+          comparer),
         enumerable,
         keySelector,
         accumulatorInitializer,
@@ -1360,8 +1360,7 @@ public abstract class EnumerableDefaults {
     if (list != null) {
       final List<TSource> rawList = list.toList();
       final int count = rawList.size();
-      for (int i = count - 1; i >= 0; --i)
-      {
+      for (int i = count - 1; i >= 0; --i) {
         TSource result = rawList.get(i);
         if (predicate.apply(result)) {
           return result;
@@ -1434,8 +1433,7 @@ public abstract class EnumerableDefaults {
     if (list != null) {
       final List<TSource> rawList = list.toList();
       final int count = rawList.size();
-      for (int i = count - 1; i >= 0; --i)
-      {
+      for (int i = count - 1; i >= 0; --i) {
         TSource result = rawList.get(i);
         if (predicate.apply(result)) {
           return result;
@@ -2035,12 +2033,13 @@ public abstract class EnumerableDefaults {
               final TSource sourceElement = sourceEnumerator.current();
               collectionEnumerator = collectionSelector.apply(sourceElement, index)
                   .enumerator();
-              resultEnumerator = new TransformedEnumerator<TCollection, TResult>(collectionEnumerator) {
-                @Override
-                protected TResult transform(TCollection collectionElement) {
-                  return resultSelector.apply(sourceElement, collectionElement);
-                }
-              };
+              resultEnumerator =
+                  new TransformedEnumerator<TCollection, TResult>(collectionEnumerator) {
+                    @Override
+                    protected TResult transform(TCollection collectionElement) {
+                      return resultSelector.apply(sourceElement, collectionElement);
+                    }
+                  };
             }
           }
 
@@ -2091,12 +2090,13 @@ public abstract class EnumerableDefaults {
               final TSource sourceElement = sourceEnumerator.current();
               collectionEnumerator = collectionSelector.apply(sourceElement)
                   .enumerator();
-              resultEnumerator = new TransformedEnumerator<TCollection, TResult>(collectionEnumerator) {
-                @Override
-                protected TResult transform(TCollection collectionElement) {
-                  return resultSelector.apply(sourceElement, collectionElement);
-                }
-              };
+              resultEnumerator =
+                  new TransformedEnumerator<TCollection, TResult>(collectionEnumerator) {
+                    @Override
+                    protected TResult transform(TCollection collectionElement) {
+                      return resultSelector.apply(sourceElement, collectionElement);
+                    }
+                  };
             }
           }
 
@@ -2153,8 +2153,10 @@ public abstract class EnumerableDefaults {
       final CollectionEnumerable<TSource> secondCollection = second instanceof CollectionEnumerable
           ? ((CollectionEnumerable<TSource>) second)
           : null;
-      if (secondCollection != null && firstCollection.getCollection().size() != secondCollection.getCollection().size()) {
-        return false;
+      if (secondCollection != null) {
+        if (firstCollection.getCollection().size() != secondCollection.getCollection().size()) {
+          return false;
+        }
       }
     }
 
@@ -2704,13 +2706,13 @@ public abstract class EnumerableDefaults {
       EqualityComparer<TKey> comparer) {
     return toLookup_(
         new WrapMap<TKey, List<TElement>>(
-            new Function0<Map<Wrapped<TKey>, List<TElement>>>() {
-              @Override
-              public Map<Wrapped<TKey>, List<TElement>> apply() {
-                return new HashMap<Wrapped<TKey>, List<TElement>>();
-              }
-            },
-            comparer),
+          new Function0<Map<Wrapped<TKey>, List<TElement>>>() {
+            @Override
+            public Map<Wrapped<TKey>, List<TElement>> apply() {
+              return new HashMap<Wrapped<TKey>, List<TElement>>();
+            }
+          },
+          comparer),
         source,
         keySelector,
         elementSelector);

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableQueryable.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableQueryable.java
@@ -267,14 +267,6 @@ class EnumerableQueryable<T> extends DefaultEnumerable<T>
         elementSelector.getFunction()).asQueryable();
   }
 
-  public <TKey, TResult> Queryable<Grouping<TKey, TResult>> groupByK(
-      FunctionExpression<Function1<T, TKey>> keySelector,
-      FunctionExpression<Function2<TKey, Enumerable<T>, TResult>>
-        elementSelector) {
-    return EnumerableDefaults.groupBy(getThis(), keySelector.getFunction(),
-        elementSelector.getFunction()).asQueryable();
-  }
-
   public <TKey, TElement> Queryable<Grouping<TKey, TElement>> groupBy(
       FunctionExpression<Function1<T, TKey>> keySelector,
       FunctionExpression<Function1<T, TElement>> elementSelector,
@@ -285,18 +277,23 @@ class EnumerableQueryable<T> extends DefaultEnumerable<T>
 
   public <TKey, TResult> Queryable<TResult> groupByK(
       FunctionExpression<Function1<T, TKey>> keySelector,
-      FunctionExpression<Function2<TKey, Enumerable<T>, TResult>>
-        elementSelector,
+      FunctionExpression<Function2<TKey, Enumerable<T>, TResult>> resultSelector) {
+    return EnumerableDefaults.groupBy(getThis(), keySelector.getFunction(),
+        resultSelector.getFunction()).asQueryable();
+  }
+
+  public <TKey, TResult> Queryable<TResult> groupByK(
+      FunctionExpression<Function1<T, TKey>> keySelector,
+      FunctionExpression<Function2<TKey, Enumerable<T>, TResult>> resultSelector,
       EqualityComparer<TKey> comparer) {
     return EnumerableDefaults.groupBy(getThis(), keySelector.getFunction(),
-        elementSelector.getFunction(), comparer).asQueryable();
+        resultSelector.getFunction(), comparer).asQueryable();
   }
 
   public <TKey, TElement, TResult> Queryable<TResult> groupBy(
       FunctionExpression<Function1<T, TKey>> keySelector,
       FunctionExpression<Function1<T, TElement>> elementSelector,
-      FunctionExpression<Function2<TKey, Enumerable<TElement>, TResult>>
-        resultSelector) {
+      FunctionExpression<Function2<TKey, Enumerable<TElement>, TResult>> resultSelector) {
     return EnumerableDefaults.groupBy(getThis(), keySelector.getFunction(),
         elementSelector.getFunction(), resultSelector.getFunction())
         .asQueryable();
@@ -305,8 +302,7 @@ class EnumerableQueryable<T> extends DefaultEnumerable<T>
   public <TKey, TElement, TResult> Queryable<TResult> groupBy(
       FunctionExpression<Function1<T, TKey>> keySelector,
       FunctionExpression<Function1<T, TElement>> elementSelector,
-      FunctionExpression<Function2<TKey, Enumerable<TElement>, TResult>>
-        resultSelector,
+      FunctionExpression<Function2<TKey, Enumerable<TElement>, TResult>> resultSelector,
       EqualityComparer<TKey> comparer) {
     return EnumerableDefaults.groupBy(getThis(), keySelector.getFunction(),
         elementSelector.getFunction(), resultSelector.getFunction(), comparer)
@@ -317,8 +313,7 @@ class EnumerableQueryable<T> extends DefaultEnumerable<T>
       Enumerable<TInner> inner,
       FunctionExpression<Function1<T, TKey>> outerKeySelector,
       FunctionExpression<Function1<TInner, TKey>> innerKeySelector,
-      FunctionExpression<Function2<T, Enumerable<TInner>, TResult>>
-        resultSelector) {
+      FunctionExpression<Function2<T, Enumerable<TInner>, TResult>> resultSelector) {
     return EnumerableDefaults.groupJoin(getThis(), inner,
         outerKeySelector.getFunction(), innerKeySelector.getFunction(),
         resultSelector.getFunction()).asQueryable();
@@ -328,8 +323,7 @@ class EnumerableQueryable<T> extends DefaultEnumerable<T>
       Enumerable<TInner> inner,
       FunctionExpression<Function1<T, TKey>> outerKeySelector,
       FunctionExpression<Function1<TInner, TKey>> innerKeySelector,
-      FunctionExpression<Function2<T, Enumerable<TInner>, TResult>>
-        resultSelector,
+      FunctionExpression<Function2<T, Enumerable<TInner>, TResult>> resultSelector,
       EqualityComparer<TKey> comparer) {
     return EnumerableDefaults.groupJoin(getThis(), inner,
         outerKeySelector.getFunction(), innerKeySelector.getFunction(),

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/ExtendedEnumerable.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/ExtendedEnumerable.java
@@ -270,7 +270,7 @@ public interface ExtendedEnumerable<TSource> {
    * the specified value in a singleton collection if the sequence
    * is empty.
    */
-  TSource defaultIfEmpty(TSource value);
+  Enumerable<TSource>  defaultIfEmpty(TSource value);
 
   /**
    * Returns distinct elements from a sequence by using

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/ExtendedEnumerable.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/ExtendedEnumerable.java
@@ -363,22 +363,22 @@ public interface ExtendedEnumerable<TSource> {
 
   /**
    * Groups the elements of a sequence according to a
-   * specified key selector function and creates a result value from
-   * each group and its key.
-   */
-  <TKey, TResult> Enumerable<Grouping<TKey, TResult>> groupBy(
-      Function1<TSource, TKey> keySelector,
-      Function2<TKey, Enumerable<TSource>, TResult> elementSelector);
-
-  /**
-   * Groups the elements of a sequence according to a
    * key selector function. The keys are compared by using a
    * comparer and each group's elements are projected by using a
    * specified function.
    */
   <TKey, TElement> Enumerable<Grouping<TKey, TElement>> groupBy(
       Function1<TSource, TKey> keySelector,
-      Function1<TSource, TElement> elementSelector, EqualityComparer comparer);
+      Function1<TSource, TElement> elementSelector, EqualityComparer<TKey> comparer);
+
+  /**
+   * Groups the elements of a sequence according to a
+   * specified key selector function and creates a result value from
+   * each group and its key.
+   */
+  <TKey, TResult> Enumerable<TResult> groupBy(
+      Function1<TSource, TKey> keySelector,
+      Function2<TKey, Enumerable<TSource>, TResult> resultSelector);
 
   /**
    * Groups the elements of a sequence according to a
@@ -388,8 +388,8 @@ public interface ExtendedEnumerable<TSource> {
    */
   <TKey, TResult> Enumerable<TResult> groupBy(
       Function1<TSource, TKey> keySelector,
-      Function2<TKey, Enumerable<TSource>, TResult> elementSelector,
-      EqualityComparer comparer);
+      Function2<TKey, Enumerable<TSource>, TResult> resultSelector,
+      EqualityComparer<TKey> comparer);
 
   /**
    * Groups the elements of a sequence according to a

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/ExtendedQueryable.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/ExtendedQueryable.java
@@ -240,20 +240,6 @@ interface ExtendedQueryable<TSource> extends ExtendedEnumerable<TSource> {
       FunctionExpression<Function1<TSource, TElement>> elementSelector);
 
   /**
-   * Groups the elements of a sequence according to a
-   * specified key selector function and creates a result value from
-   * each group and its key.
-   *
-   * <p>NOTE: Renamed from {@code groupBy} to distinguish from
-   * {@link #groupBy(org.apache.calcite.linq4j.tree.FunctionExpression, org.apache.calcite.linq4j.tree.FunctionExpression)},
-   * which has the same erasure.</p>
-   */
-  <TKey, TResult> Queryable<Grouping<TKey, TResult>> groupByK(
-      FunctionExpression<Function1<TSource, TKey>> keySelector,
-      FunctionExpression<Function2<TKey, Enumerable<TSource>, TResult>>
-        elementSelector);
-
-  /**
    * Groups the elements of a sequence and projects the
    * elements for each group by using a specified function. Key
    * values are compared by using a specified comparer.
@@ -266,13 +252,25 @@ interface ExtendedQueryable<TSource> extends ExtendedEnumerable<TSource> {
   /**
    * Groups the elements of a sequence according to a
    * specified key selector function and creates a result value from
+   * each group and its key.
+   *
+   * <p>NOTE: Renamed from {@code groupBy} to distinguish from
+   * {@link #groupBy(org.apache.calcite.linq4j.tree.FunctionExpression, org.apache.calcite.linq4j.tree.FunctionExpression)},
+   * which has the same erasure.</p>
+   */
+  <TKey, TResult> Queryable<TResult> groupByK(
+      FunctionExpression<Function1<TSource, TKey>> keySelector,
+      FunctionExpression<Function2<TKey, Enumerable<TSource>, TResult>> resultSelector);
+
+  /**
+   * Groups the elements of a sequence according to a
+   * specified key selector function and creates a result value from
    * each group and its key. Keys are compared by using a specified
    * comparer.
    */
   <TKey, TResult> Queryable<TResult> groupByK(
       FunctionExpression<Function1<TSource, TKey>> keySelector,
-      FunctionExpression<Function2<TKey, Enumerable<TSource>, TResult>>
-        elementSelector,
+      FunctionExpression<Function2<TKey, Enumerable<TSource>, TResult>> resultSelector,
       EqualityComparer<TKey> comparer);
 
   /**

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/QueryableFactory.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/QueryableFactory.java
@@ -302,16 +302,6 @@ public interface QueryableFactory<T> {
       FunctionExpression<Function1<T, TElement>> elementSelector);
 
   /**
-   * Groups the elements of a sequence according to a
-   * specified key selector function and creates a result value from
-   * each group and its key.
-   */
-  <TKey, TResult> Queryable<Grouping<TKey, TResult>> groupByK(
-      Queryable<T> source, FunctionExpression<Function1<T, TKey>> keySelector,
-      FunctionExpression<Function2<TKey, Enumerable<T>, TResult>>
-        elementSelector);
-
-  /**
    * Groups the elements of a sequence and projects the
    * elements for each group by using a specified function. Key
    * values are compared by using a specified comparer.
@@ -324,13 +314,21 @@ public interface QueryableFactory<T> {
   /**
    * Groups the elements of a sequence according to a
    * specified key selector function and creates a result value from
+   * each group and its key.
+   */
+  <TKey, TResult> Queryable<TResult> groupByK(
+      Queryable<T> source, FunctionExpression<Function1<T, TKey>> keySelector,
+      FunctionExpression<Function2<TKey, Enumerable<T>, TResult>> resultSelector);
+
+  /**
+   * Groups the elements of a sequence according to a
+   * specified key selector function and creates a result value from
    * each group and its key. Keys are compared by using a specified
    * comparer.
    */
   <TKey, TResult> Queryable<TResult> groupByK(Queryable<T> source,
       FunctionExpression<Function1<T, TKey>> keySelector,
-      FunctionExpression<Function2<TKey, Enumerable<T>, TResult>>
-        elementSelector,
+      FunctionExpression<Function2<TKey, Enumerable<T>, TResult>> resultSelector,
       EqualityComparer<TKey> comparer);
 
   /**
@@ -342,8 +340,7 @@ public interface QueryableFactory<T> {
   <TKey, TElement, TResult> Queryable<TResult> groupBy(Queryable<T> source,
       FunctionExpression<Function1<T, TKey>> keySelector,
       FunctionExpression<Function1<T, TElement>> elementSelector,
-      FunctionExpression<Function2<TKey, Enumerable<TElement>, TResult>>
-        resultSelector);
+      FunctionExpression<Function2<TKey, Enumerable<TElement>, TResult>> resultSelector);
 
   /**
    * Groups the elements of a sequence according to a
@@ -355,8 +352,7 @@ public interface QueryableFactory<T> {
   <TKey, TElement, TResult> Queryable<TResult> groupBy(Queryable<T> source,
       FunctionExpression<Function1<T, TKey>> keySelector,
       FunctionExpression<Function1<T, TElement>> elementSelector,
-      FunctionExpression<Function2<TKey, Enumerable<TElement>, TResult>>
-        resultSelector,
+      FunctionExpression<Function2<TKey, Enumerable<TElement>, TResult>> resultSelector,
       EqualityComparer<TKey> comparer);
 
   /**
@@ -368,8 +364,7 @@ public interface QueryableFactory<T> {
       Enumerable<TInner> inner,
       FunctionExpression<Function1<T, TKey>> outerKeySelector,
       FunctionExpression<Function1<TInner, TKey>> innerKeySelector,
-      FunctionExpression<Function2<T, Enumerable<TInner>, TResult>>
-        resultSelector);
+      FunctionExpression<Function2<T, Enumerable<TInner>, TResult>> resultSelector);
 
   /**
    * Correlates the elements of two sequences based on
@@ -380,8 +375,7 @@ public interface QueryableFactory<T> {
       Enumerable<TInner> inner,
       FunctionExpression<Function1<T, TKey>> outerKeySelector,
       FunctionExpression<Function1<TInner, TKey>> innerKeySelector,
-      FunctionExpression<Function2<T, Enumerable<TInner>, TResult>>
-        resultSelector,
+      FunctionExpression<Function2<T, Enumerable<TInner>, TResult>> resultSelector,
       EqualityComparer<TKey> comparer);
 
   /**

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/QueryableRecorder.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/QueryableRecorder.java
@@ -384,18 +384,6 @@ public class QueryableRecorder<T> implements QueryableFactory<T> {
     }.castQueryable(); // CHECKSTYLE: IGNORE 0
   }
 
-  public <TKey, TResult> Queryable<Grouping<TKey, TResult>> groupByK(
-      final Queryable<T> source,
-      final FunctionExpression<Function1<T, TKey>> keySelector,
-      final FunctionExpression<Function2<TKey, Enumerable<T>, TResult>>
-        elementSelector) {
-    return new NonLeafReplayableQueryable<T>(source) {
-      public void replay(QueryableFactory<T> factory) {
-        factory.groupByK(source, keySelector, elementSelector);
-      }
-    }.castQueryable(); // CHECKSTYLE: IGNORE 0
-  }
-
   public <TKey, TElement> Queryable<Grouping<TKey, TElement>> groupBy(
       final Queryable<T> source,
       final FunctionExpression<Function1<T, TKey>> keySelector,
@@ -408,14 +396,24 @@ public class QueryableRecorder<T> implements QueryableFactory<T> {
     }.castQueryable(); // CHECKSTYLE: IGNORE 0
   }
 
+  public <TKey, TResult> Queryable<TResult> groupByK(
+      final Queryable<T> source,
+      final FunctionExpression<Function1<T, TKey>> keySelector,
+      final FunctionExpression<Function2<TKey, Enumerable<T>, TResult>> resultSelector) {
+    return new NonLeafReplayableQueryable<T>(source) {
+      public void replay(QueryableFactory<T> factory) {
+        factory.groupByK(source, keySelector, resultSelector);
+      }
+    }.castQueryable(); // CHECKSTYLE: IGNORE 0
+  }
+
   public <TKey, TResult> Queryable<TResult> groupByK(final Queryable<T> source,
       final FunctionExpression<Function1<T, TKey>> keySelector,
-      final FunctionExpression<Function2<TKey, Enumerable<T>, TResult>>
-        elementSelector,
+      final FunctionExpression<Function2<TKey, Enumerable<T>, TResult>> resultSelector,
       final EqualityComparer<TKey> comparer) {
     return new NonLeafReplayableQueryable<T>(source) {
       public void replay(QueryableFactory<T> factory) {
-        factory.groupByK(source, keySelector, elementSelector, comparer);
+        factory.groupByK(source, keySelector, resultSelector, comparer);
       }
     }.castQueryable(); // CHECKSTYLE: IGNORE 0
   }
@@ -424,8 +422,7 @@ public class QueryableRecorder<T> implements QueryableFactory<T> {
       final Queryable<T> source,
       final FunctionExpression<Function1<T, TKey>> keySelector,
       final FunctionExpression<Function1<T, TElement>> elementSelector,
-      final FunctionExpression<Function2<TKey, Enumerable<TElement>, TResult>>
-        resultSelector) {
+      final FunctionExpression<Function2<TKey, Enumerable<TElement>, TResult>> resultSelector) {
     return new NonLeafReplayableQueryable<T>(source) {
       public void replay(QueryableFactory<T> factory) {
         factory.groupBy(source, keySelector, elementSelector, resultSelector);
@@ -437,8 +434,7 @@ public class QueryableRecorder<T> implements QueryableFactory<T> {
       final Queryable<T> source,
       final FunctionExpression<Function1<T, TKey>> keySelector,
       final FunctionExpression<Function1<T, TElement>> elementSelector,
-      final FunctionExpression<Function2<TKey, Enumerable<TElement>, TResult>>
-        resultSelector,
+      final FunctionExpression<Function2<TKey, Enumerable<TElement>, TResult>> resultSelector,
       final EqualityComparer<TKey> comparer) {
     return new NonLeafReplayableQueryable<T>(source) {
       public void replay(QueryableFactory<T> factory) {
@@ -452,8 +448,7 @@ public class QueryableRecorder<T> implements QueryableFactory<T> {
       final Queryable<T> source, final Enumerable<TInner> inner,
       final FunctionExpression<Function1<T, TKey>> outerKeySelector,
       final FunctionExpression<Function1<TInner, TKey>> innerKeySelector,
-      final FunctionExpression<Function2<T, Enumerable<TInner>, TResult>>
-        resultSelector) {
+      final FunctionExpression<Function2<T, Enumerable<TInner>, TResult>> resultSelector) {
     return new NonLeafReplayableQueryable<T>(source) {
       public void replay(QueryableFactory<T> factory) {
         factory.groupJoin(source, inner, outerKeySelector, innerKeySelector,
@@ -466,8 +461,7 @@ public class QueryableRecorder<T> implements QueryableFactory<T> {
       final Queryable<T> source, final Enumerable<TInner> inner,
       final FunctionExpression<Function1<T, TKey>> outerKeySelector,
       final FunctionExpression<Function1<TInner, TKey>> innerKeySelector,
-      final FunctionExpression<Function2<T, Enumerable<TInner>, TResult>>
-        resultSelector,
+      final FunctionExpression<Function2<T, Enumerable<TInner>, TResult>> resultSelector,
       final EqualityComparer<TKey> comparer) {
     return new NonLeafReplayableQueryable<T>(source) {
       public void replay(QueryableFactory<T> factory) {

--- a/linq4j/src/test/java/org/apache/calcite/linq4j/test/Linq4jTest.java
+++ b/linq4j/src/test/java/org/apache/calcite/linq4j/test/Linq4jTest.java
@@ -2047,6 +2047,194 @@ public class Linq4jTest {
     assertFalse(enumerable1.sequenceEqual(enumerable2.skip(1)));
   }
 
+  @Test public void testGroupByWithKeySelector() {
+    String s =
+        Linq4j.asEnumerable(emps)
+            .groupBy(EMP_DEPTNO_SELECTOR)
+            .select(new Function1<Grouping<Integer,Employee>, String>() {
+              @Override
+              public String apply(Grouping<Integer, Employee> group) {
+                return String.format("%s: %s", group.getKey(), String.join("+", group.select(new Function1<Employee, String>() {
+                  @Override
+                  public String apply(Employee element) {
+                    return element.name;
+                  }
+                })));
+              }
+            })
+            .toList()
+            .toString();
+    assertEquals(
+        "[10: Fred+Eric+Janet, 30: Bill]",
+        s);
+  }
+
+  @Test public void testGroupByWithKeySelectorAndComparer() {
+    String s =
+        Linq4j.asEnumerable(emps)
+            .groupBy(EMP_DEPTNO_SELECTOR, new EqualityComparer<Integer>() {
+              @Override
+              public boolean equal(Integer v1, Integer v2) {
+                return true;
+              }
+              @Override
+              public int hashCode(Integer integer) {
+                return 0;
+              }
+            })
+            .select(new Function1<Grouping<Integer,Employee>, String>() {
+              @Override
+              public String apply(Grouping<Integer, Employee> group) {
+                return String.format("%s: %s", group.getKey(), String.join("+", group.select(new Function1<Employee, String>() {
+                  @Override
+                  public String apply(Employee element) {
+                    return element.name;
+                  }
+                })));
+              }
+            })
+            .toList()
+            .toString();
+    assertEquals(
+        "[10: Fred+Bill+Eric+Janet]",
+        s);
+  }
+
+  @Test public void testGroupByWithKeySelectorAndElementSelector() {
+    String s =
+        Linq4j.asEnumerable(emps)
+            .groupBy(EMP_DEPTNO_SELECTOR, EMP_NAME_SELECTOR)
+            .select(new Function1<Grouping<Integer,String>, String>() {
+              @Override
+              public String apply(Grouping<Integer, String> group) {
+                return String.format("%s: %s", group.getKey(), String.join("+", group));
+              }
+            })
+            .toList()
+            .toString();
+    assertEquals(
+        "[10: Fred+Eric+Janet, 30: Bill]",
+        s);
+  }
+
+  @Test public void testGroupByWithKeySelectorAndElementSelectorAndComparer() {
+    String s =
+        Linq4j.asEnumerable(emps)
+            .groupBy(EMP_DEPTNO_SELECTOR, EMP_NAME_SELECTOR,  new EqualityComparer<Integer>() {
+              @Override
+              public boolean equal(Integer v1, Integer v2) {
+                return true;
+              }
+              @Override
+              public int hashCode(Integer integer) {
+                return 0;
+              }
+            })
+            .select(new Function1<Grouping<Integer,String>, String>() {
+              @Override
+              public String apply(Grouping<Integer, String> group) {
+                return String.format("%s: %s", group.getKey(), String.join("+", group));
+              }
+            })
+            .toList()
+            .toString();
+    assertEquals(
+        "[10: Fred+Bill+Eric+Janet]",
+        s);
+  }
+
+  @Test public void testGroupByWithKeySelectorAndResultSelector() {
+    String s =
+        Linq4j.asEnumerable(emps)
+            .groupBy(EMP_DEPTNO_SELECTOR, new Function2<Integer, Enumerable<Employee>, String>() {
+              @Override
+              public String apply(Integer key, Enumerable<Employee> group) {
+                return String.format("%s: %s", key, String.join("+", group.select(new Function1<Employee, String>() {
+                  @Override
+                  public String apply(Employee element) {
+                    return element.name;
+                  }
+                })));
+              }
+            })
+            .toList()
+            .toString();
+    assertEquals(
+        "[10: Fred+Eric+Janet, 30: Bill]",
+        s);
+  }
+
+  @Test public void testGroupByWithKeySelectorAndResultSelectorAndComparer() {
+    String s =
+        Linq4j.asEnumerable(emps)
+            .groupBy(EMP_DEPTNO_SELECTOR, new Function2<Integer, Enumerable<Employee>, String>() {
+              @Override
+              public String apply(Integer key, Enumerable<Employee> group) {
+                return String.format("%s: %s", key, String.join("+", group.select(new Function1<Employee, String>() {
+                  @Override
+                  public String apply(Employee element) {
+                    return element.name;
+                  }
+                })));
+              }
+            }, new EqualityComparer<Integer>() {
+              @Override
+              public boolean equal(Integer v1, Integer v2) {
+                return true;
+              }
+              @Override
+              public int hashCode(Integer integer) {
+                return 0;
+              }
+            })
+            .toList()
+            .toString();
+    assertEquals(
+        "[10: Fred+Bill+Eric+Janet]",
+        s);
+  }
+
+  @Test public void testGroupByWithKeySelectorAndElementSelectorAndResultSelector() {
+    String s =
+        Linq4j.asEnumerable(emps)
+            .groupBy(EMP_DEPTNO_SELECTOR, EMP_NAME_SELECTOR, new Function2<Integer, Enumerable<String>, String>() {
+              @Override
+              public String apply(Integer key, Enumerable<String> group) {
+                return String.format("%s: %s", key, String.join("+", group));
+              }
+            })
+            .toList()
+            .toString();
+    assertEquals(
+        "[10: Fred+Eric+Janet, 30: Bill]",
+        s);
+  }
+
+  @Test public void testGroupByWithKeySelectorAndElementSelectorAndResultSelectorAndComparer() {
+    String s =
+        Linq4j.asEnumerable(emps)
+            .groupBy(EMP_DEPTNO_SELECTOR, EMP_NAME_SELECTOR, new Function2<Integer, Enumerable<String>, String>() {
+              @Override
+              public String apply(Integer key, Enumerable<String> group) {
+                return String.format("%s: %s", key, String.join("+", group));
+              }
+            }, new EqualityComparer<Integer>() {
+              @Override
+              public boolean equal(Integer v1, Integer v2) {
+                return true;
+              }
+              @Override
+              public int hashCode(Integer integer) {
+                return 0;
+              }
+            })
+            .toList()
+            .toString();
+    assertEquals(
+        "[10: Fred+Bill+Eric+Janet]",
+        s);
+  }
+
   private static int count(Enumerator<String> enumerator) {
     int n = 0;
     while (enumerator.moveNext()) {

--- a/linq4j/src/test/java/org/apache/calcite/linq4j/test/Linq4jTest.java
+++ b/linq4j/src/test/java/org/apache/calcite/linq4j/test/Linq4jTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.calcite.linq4j.test;
 
-import com.example.Linq4jExample;
-import com.google.common.collect.Lists;
 import org.apache.calcite.linq4j.AbstractEnumerable;
 import org.apache.calcite.linq4j.Enumerable;
 import org.apache.calcite.linq4j.EnumerableDefaults;
@@ -39,6 +37,11 @@ import org.apache.calcite.linq4j.function.Predicate2;
 import org.apache.calcite.linq4j.tree.ConstantExpression;
 import org.apache.calcite.linq4j.tree.Expressions;
 import org.apache.calcite.linq4j.tree.ParameterExpression;
+
+import com.example.Linq4jExample;
+
+import com.google.common.collect.Lists;
+
 import org.junit.Test;
 
 import java.math.BigDecimal;
@@ -53,8 +56,18 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.TreeSet;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for LINQ4J.
@@ -1753,7 +1766,8 @@ public class Linq4jTest {
     notEmptyEnumerator.moveNext();
     assertEquals("noel", notEmptyEnumerator.current());
 
-    final Enumerable<String> emptyEnumerable = Linq4j.asEnumerable(Linq4j.<String>emptyEnumerable()).defaultIfEmpty();
+    final Enumerable<String> emptyEnumerable =
+        Linq4j.asEnumerable(Linq4j.<String>emptyEnumerable()).defaultIfEmpty();
     final Enumerator<String> emptyEnumerator = emptyEnumerable.enumerator();
     assertTrue(emptyEnumerator.moveNext());
     assertNull(emptyEnumerator.current());
@@ -1762,7 +1776,8 @@ public class Linq4jTest {
 
   @Test public void testDefaultIfEmpty2() {
     final List<String> experience = Arrays.asList("jimi", "mitch", "noel");
-    final Enumerable<String> notEmptyEnumerable = Linq4j.asEnumerable(experience).defaultIfEmpty("dummy");
+    final Enumerable<String> notEmptyEnumerable =
+        Linq4j.asEnumerable(experience).defaultIfEmpty("dummy");
     final Enumerator<String> notEmptyEnumerator = notEmptyEnumerable.enumerator();
     notEmptyEnumerator.moveNext();
     assertEquals("jimi", notEmptyEnumerator.current());
@@ -1771,7 +1786,8 @@ public class Linq4jTest {
     notEmptyEnumerator.moveNext();
     assertEquals("noel", notEmptyEnumerator.current());
 
-    final Enumerable<String> emptyEnumerable = Linq4j.asEnumerable(Linq4j.<String>emptyEnumerable()).defaultIfEmpty("N/A");
+    final Enumerable<String> emptyEnumerable =
+        Linq4j.asEnumerable(Linq4j.<String>emptyEnumerable()).defaultIfEmpty("N/A");
     final Enumerator<String> emptyEnumerator = emptyEnumerable.enumerator();
     assertTrue(emptyEnumerator.moveNext());
     assertEquals("N/A", emptyEnumerator.current());
@@ -1785,26 +1801,31 @@ public class Linq4jTest {
       enumerable.elementAt(2);
       fail();
     } catch (Exception ignored) {
+      // ok
     }
     try {
       enumerable.elementAt(-1);
       fail();
     } catch (Exception ignored) {
+      // ok
     }
   }
 
   @Test public void testElementAtWithoutList() {
-    final Enumerable<String> enumerable = Linq4j.asEnumerable(Collections.unmodifiableCollection(Arrays.asList("jimi", "mitch")));
+    final Enumerable<String> enumerable =
+        Linq4j.asEnumerable(Collections.unmodifiableCollection(Arrays.asList("jimi", "mitch")));
     assertEquals("jimi", enumerable.elementAt(0));
     try {
       enumerable.elementAt(2);
       fail();
     } catch (Exception ignored) {
+      // ok
     }
     try {
       enumerable.elementAt(-1);
       fail();
     } catch (Exception ignored) {
+      // ok
     }
   }
 
@@ -1816,17 +1837,20 @@ public class Linq4jTest {
   }
 
   @Test public void testElementAtOrDefaultWithoutList() {
-    final Enumerable<String> enumerable = Linq4j.asEnumerable(Collections.unmodifiableCollection(Arrays.asList("jimi", "mitch")));
+    final Enumerable<String> enumerable =
+        Linq4j.asEnumerable(Collections.unmodifiableCollection(Arrays.asList("jimi", "mitch")));
     assertEquals("jimi", enumerable.elementAt(0));
     try {
       enumerable.elementAt(2);
       fail();
     } catch (Exception ignored) {
+      // ok
     }
     try {
       enumerable.elementAt(-1);
       fail();
     } catch (Exception ignored) {
+      // ok
     }
   }
 
@@ -1839,11 +1863,13 @@ public class Linq4jTest {
       emptyEnumerable.last();
       fail();
     } catch (Exception ignored) {
+      // ok
     }
   }
 
   @Test public void testLastWithoutList() {
-    final Enumerable<String> enumerable = Linq4j.asEnumerable(Collections.unmodifiableCollection(Arrays.asList("jimi", "mitch")));
+    final Enumerable<String> enumerable =
+        Linq4j.asEnumerable(Collections.unmodifiableCollection(Arrays.asList("jimi", "mitch")));
     assertEquals("mitch", enumerable.last());
   }
 
@@ -1856,7 +1882,8 @@ public class Linq4jTest {
   }
 
   @Test public void testLastWithPredicate() {
-    final Enumerable<String> enumerable = Linq4j.asEnumerable(Arrays.asList("jimi", "mitch", "ming"));
+    final Enumerable<String> enumerable =
+        Linq4j.asEnumerable(Arrays.asList("jimi", "mitch", "ming"));
     assertEquals("mitch", enumerable.last(new Predicate1<String>() {
       @Override
       public boolean apply(String x) {
@@ -1872,6 +1899,7 @@ public class Linq4jTest {
       });
       fail();
     } catch (Exception ignored) {
+      // ok
     }
 
     @SuppressWarnings("unchecked")
@@ -1886,11 +1914,13 @@ public class Linq4jTest {
       });
       fail();
     } catch (Exception ignored) {
+      // ok
     }
   }
 
   @Test public void testLastOrDefaultWithPredicate() {
-    final Enumerable<String> enumerable = Linq4j.asEnumerable(Arrays.asList("jimi", "mitch", "ming"));
+    final Enumerable<String> enumerable =
+        Linq4j.asEnumerable(Arrays.asList("jimi", "mitch", "ming"));
     assertEquals("mitch", enumerable.lastOrDefault(new Predicate1<String>() {
       @Override
       public boolean apply(String x) {
@@ -1956,7 +1986,8 @@ public class Linq4jTest {
             })
             .toList();
     assertEquals(
-        "[#0: Fred@Sales, #1: Eric@Sales, #2: Janet@Sales, #3: Bill@Marketing]", nameSeqs.toString());
+        "[#0: Fred@Sales, #1: Eric@Sales, #2: Janet@Sales, #3: Bill@Marketing]",
+        nameSeqs.toString());
   }
 
   @Test public void testSelectManyWithIndexableSelectorAndResultSelector() {
@@ -1986,7 +2017,8 @@ public class Linq4jTest {
             })
             .toList();
     assertEquals(
-        "[#0: Fred@Sales, #1: Eric@Sales, #2: Janet@Sales, #3: Bill@Marketing]", nameSeqs.toString());
+        "[#0: Fred@Sales, #1: Eric@Sales, #2: Janet@Sales, #3: Bill@Marketing]",
+        nameSeqs.toString());
   }
 
   @Test public void testSequenceEqual() {
@@ -2001,16 +2033,19 @@ public class Linq4jTest {
       EnumerableDefaults.sequenceEqual(null, enumerable2);
       fail();
     } catch (NullPointerException ignored) {
+      // ok
     }
     try {
       EnumerableDefaults.sequenceEqual(enumerable1, null);
       fail();
     } catch (NullPointerException ignored) {
+      // ok
     }
 
     assertFalse(Linq4j.asEnumerable(enumerable1.skip(1).toList()) // Keep as collection
         .sequenceEqual(enumerable2));
-    assertFalse(enumerable1.sequenceEqual(Linq4j.asEnumerable(enumerable2.skip(1).toList()))); // Keep as collection
+    assertFalse(enumerable1
+        .sequenceEqual(Linq4j.asEnumerable(enumerable2.skip(1).toList()))); // Keep as collection
   }
 
   @Test public void testSequenceEqualWithoutCollection() {
@@ -2038,11 +2073,13 @@ public class Linq4jTest {
       EnumerableDefaults.sequenceEqual(null, enumerable2);
       fail();
     } catch (NullPointerException ignored) {
+      // ok
     }
     try {
       EnumerableDefaults.sequenceEqual(enumerable1, null);
       fail();
     } catch (NullPointerException ignored) {
+      // ok
     }
 
     assertFalse(enumerable1.skip(1).sequenceEqual(enumerable2));
@@ -2066,22 +2103,26 @@ public class Linq4jTest {
       }
     };
     assertFalse(enumerable1.sequenceEqual(enumerable2, equalityComparer));
-    assertTrue(enumerable1.sequenceEqual(Linq4j.asEnumerable(Arrays.asList("fun", "lol", "far")), equalityComparer));
+    assertTrue(enumerable1
+        .sequenceEqual(Linq4j.asEnumerable(Arrays.asList("fun", "lol", "far")), equalityComparer));
 
     try {
       EnumerableDefaults.sequenceEqual(null, enumerable2);
       fail();
-    } catch(NullPointerException ignored) {
+    } catch (NullPointerException ignored) {
+      // ok
     }
     try {
       EnumerableDefaults.sequenceEqual(enumerable1, null);
       fail();
-    } catch(NullPointerException ignored) {
+    } catch (NullPointerException ignored) {
+      // ok
     }
 
     assertFalse(Linq4j.asEnumerable(enumerable1.skip(1).toList()) // Keep as collection
         .sequenceEqual(enumerable2));
-    assertFalse(enumerable1.sequenceEqual(Linq4j.asEnumerable(enumerable2.skip(1).toList()))); // Keep as collection
+    assertFalse(enumerable1
+        .sequenceEqual(Linq4j.asEnumerable(enumerable2.skip(1).toList()))); // Keep as collection
   }
 
   @Test public void testSequenceEqualWithComparerWithoutCollection() {
@@ -2118,12 +2159,14 @@ public class Linq4jTest {
     try {
       EnumerableDefaults.sequenceEqual(null, enumerable2);
       fail();
-    } catch(NullPointerException ignored) {
+    } catch (NullPointerException ignored) {
+      // ok
     }
     try {
       EnumerableDefaults.sequenceEqual(enumerable1, null);
       fail();
-    } catch(NullPointerException ignored) {
+    } catch (NullPointerException ignored) {
+      // ok
     }
 
     assertFalse(enumerable1.skip(1).sequenceEqual(enumerable2));
@@ -2134,15 +2177,17 @@ public class Linq4jTest {
     String s =
         Linq4j.asEnumerable(emps)
             .groupBy(EMP_DEPTNO_SELECTOR)
-            .select(new Function1<Grouping<Integer,Employee>, String>() {
+            .select(new Function1<Grouping<Integer, Employee>, String>() {
               @Override
               public String apply(Grouping<Integer, Employee> group) {
-                return String.format("%s: %s", group.getKey(), String.join("+", group.select(new Function1<Employee, String>() {
-                  @Override
-                  public String apply(Employee element) {
-                    return element.name;
-                  }
-                })));
+                return String.format("%s: %s",
+                    group.getKey(),
+                    String.join("+", group.select(new Function1<Employee, String>() {
+                      @Override
+                      public String apply(Employee element) {
+                        return element.name;
+                      }
+                    })));
               }
             })
             .toList()
@@ -2165,15 +2210,17 @@ public class Linq4jTest {
                 return 0;
               }
             })
-            .select(new Function1<Grouping<Integer,Employee>, String>() {
+            .select(new Function1<Grouping<Integer, Employee>, String>() {
               @Override
               public String apply(Grouping<Integer, Employee> group) {
-                return String.format("%s: %s", group.getKey(), String.join("+", group.select(new Function1<Employee, String>() {
-                  @Override
-                  public String apply(Employee element) {
-                    return element.name;
-                  }
-                })));
+                return String.format("%s: %s",
+                    group.getKey(),
+                    String.join("+", group.select(new Function1<Employee, String>() {
+                      @Override
+                      public String apply(Employee element) {
+                        return element.name;
+                      }
+                    })));
               }
             })
             .toList()
@@ -2187,7 +2234,7 @@ public class Linq4jTest {
     String s =
         Linq4j.asEnumerable(emps)
             .groupBy(EMP_DEPTNO_SELECTOR, EMP_NAME_SELECTOR)
-            .select(new Function1<Grouping<Integer,String>, String>() {
+            .select(new Function1<Grouping<Integer, String>, String>() {
               @Override
               public String apply(Grouping<Integer, String> group) {
                 return String.format("%s: %s", group.getKey(), String.join("+", group));
@@ -2213,7 +2260,7 @@ public class Linq4jTest {
                 return 0;
               }
             })
-            .select(new Function1<Grouping<Integer,String>, String>() {
+            .select(new Function1<Grouping<Integer, String>, String>() {
               @Override
               public String apply(Grouping<Integer, String> group) {
                 return String.format("%s: %s", group.getKey(), String.join("+", group));
@@ -2232,12 +2279,14 @@ public class Linq4jTest {
             .groupBy(EMP_DEPTNO_SELECTOR, new Function2<Integer, Enumerable<Employee>, String>() {
               @Override
               public String apply(Integer key, Enumerable<Employee> group) {
-                return String.format("%s: %s", key, String.join("+", group.select(new Function1<Employee, String>() {
-                  @Override
-                  public String apply(Employee element) {
-                    return element.name;
-                  }
-                })));
+                return String.format("%s: %s",
+                    key,
+                    String.join("+", group.select(new Function1<Employee, String>() {
+                      @Override
+                      public String apply(Employee element) {
+                        return element.name;
+                      }
+                    })));
               }
             })
             .toList()
@@ -2253,12 +2302,14 @@ public class Linq4jTest {
             .groupBy(EMP_DEPTNO_SELECTOR, new Function2<Integer, Enumerable<Employee>, String>() {
               @Override
               public String apply(Integer key, Enumerable<Employee> group) {
-                return String.format("%s: %s", key, String.join("+", group.select(new Function1<Employee, String>() {
-                  @Override
-                  public String apply(Employee element) {
-                    return element.name;
-                  }
-                })));
+                return String.format("%s: %s",
+                    key,
+                    String.join("+", group.select(new Function1<Employee, String>() {
+                      @Override
+                      public String apply(Employee element) {
+                        return element.name;
+                      }
+                    })));
               }
             }, new EqualityComparer<Integer>() {
               @Override
@@ -2280,12 +2331,13 @@ public class Linq4jTest {
   @Test public void testGroupByWithKeySelectorAndElementSelectorAndResultSelector() {
     String s =
         Linq4j.asEnumerable(emps)
-            .groupBy(EMP_DEPTNO_SELECTOR, EMP_NAME_SELECTOR, new Function2<Integer, Enumerable<String>, String>() {
-              @Override
-              public String apply(Integer key, Enumerable<String> group) {
-                return String.format("%s: %s", key, String.join("+", group));
-              }
-            })
+            .groupBy(EMP_DEPTNO_SELECTOR, EMP_NAME_SELECTOR,
+                new Function2<Integer, Enumerable<String>, String>() {
+                  @Override
+                  public String apply(Integer key, Enumerable<String> group) {
+                    return String.format("%s: %s", key, String.join("+", group));
+                  }
+                })
             .toList()
             .toString();
     assertEquals(
@@ -2296,21 +2348,24 @@ public class Linq4jTest {
   @Test public void testGroupByWithKeySelectorAndElementSelectorAndResultSelectorAndComparer() {
     String s =
         Linq4j.asEnumerable(emps)
-            .groupBy(EMP_DEPTNO_SELECTOR, EMP_NAME_SELECTOR, new Function2<Integer, Enumerable<String>, String>() {
-              @Override
-              public String apply(Integer key, Enumerable<String> group) {
-                return String.format("%s: %s", key, String.join("+", group));
-              }
-            }, new EqualityComparer<Integer>() {
-              @Override
-              public boolean equal(Integer v1, Integer v2) {
-                return true;
-              }
-              @Override
-              public int hashCode(Integer integer) {
-                return 0;
-              }
-            })
+            .groupBy(EMP_DEPTNO_SELECTOR, EMP_NAME_SELECTOR,
+                new Function2<Integer, Enumerable<String>, String>() {
+                  @Override
+                  public String apply(Integer key, Enumerable<String> group) {
+                    return String.format("%s: %s", key, String.join("+", group));
+                  }
+                },
+                new EqualityComparer<Integer>() {
+                  @Override
+                  public boolean equal(Integer v1, Integer v2) {
+                    return true;
+                  }
+
+                  @Override
+                  public int hashCode(Integer integer) {
+                    return 0;
+                  }
+                })
             .toList()
             .toString();
     assertEquals(

--- a/linq4j/src/test/java/org/apache/calcite/linq4j/test/Linq4jTest.java
+++ b/linq4j/src/test/java/org/apache/calcite/linq4j/test/Linq4jTest.java
@@ -2373,6 +2373,50 @@ public class Linq4jTest {
         s);
   }
 
+  @Test public void testZip() {
+    final Enumerable<String> e1 = Linq4j.asEnumerable(Arrays.asList("a", "b", "c"));
+    final Enumerable<String> e2 = Linq4j.asEnumerable(Arrays.asList("1", "2", "3"));
+
+    final Enumerable<String> zipped = e1.zip(e2, new Function2<String, String, String>() {
+      @Override
+      public String apply(String v0, String v1) {
+        return v0 + v1;
+      }
+    });
+    assertEquals(3, zipped.count());
+    zipped.enumerator().reset();
+    for (int i = 0; i < 3; i++) {
+      assertEquals("" + (char) ('a' + i) + (char) ('1' + i), zipped.elementAt(i));
+    }
+  }
+
+  @Test public void testZipLengthNotMatch() {
+    final Enumerable<String> e1 = Linq4j.asEnumerable(Arrays.asList("a", "b"));
+    final Enumerable<String> e2 = Linq4j.asEnumerable(Arrays.asList("1", "2", "3"));
+
+    final Function2<String, String, String> resultSelector =
+        new Function2<String, String, String>() {
+          @Override
+          public String apply(String v0, String v1) {
+            return v0 + v1;
+          }
+        };
+
+    final Enumerable<String> zipped1 = e1.zip(e2, resultSelector);
+    assertEquals(2, zipped1.count());
+    zipped1.enumerator().reset();
+    for (int i = 0; i < 2; i++) {
+      assertEquals("" + (char) ('a' + i) + (char) ('1' + i), zipped1.elementAt(i));
+    }
+
+    final Enumerable<String> zipped2 = e2.zip(e1, resultSelector);
+    assertEquals(2, zipped2.count());
+    zipped2.enumerator().reset();
+    for (int i = 0; i < 2; i++) {
+      assertEquals("" + (char) ('1' + i) + (char) ('a' + i), zipped2.elementAt(i));
+    }
+  }
+
   private static int count(Enumerator<String> enumerator) {
     int n = 0;
     while (enumerator.moveNext()) {


### PR DESCRIPTION
The linq4j has left many __todo__ methods, like `last`, `defaultIfEmpty`, `elementAt`, and `groupBy` etc.
It is annoying throwing `RuntimeException` when calling the stub methods, especially the `last` and `selectMany`.
Here, I made a patch to fill the stubs, but some methods still leave unimplement, such as `createOrderedEnumerable` and `zip`.