### PR TITLE
[CALCITE-828] Use RelBuilder in rules rather than type-specific RelNode factories

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/Contexts.java
+++ b/core/src/main/java/org/apache/calcite/plan/Contexts.java
@@ -57,11 +57,13 @@ public class Contexts {
     return new WrapContext(o);
   }
 
-  /** Returns a context that wraps an array of objects. */
+  /** Returns a context that wraps an array of objects, ignoring any nulls. */
   public static Context of(Object... os) {
     final List<Context> contexts = new ArrayList<>();
     for (Object o : os) {
-      contexts.add(of(o));
+      if (o != null) {
+        contexts.add(of(o));
+      }
     }
     return chain(contexts);
   }

--- a/core/src/main/java/org/apache/calcite/plan/RelOptRuleCall.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptRuleCall.java
@@ -214,10 +214,10 @@ public abstract class RelOptRuleCall {
   }
 
   /** Creates a {@link org.apache.calcite.tools.RelBuilder} to be used by
-   * code within the call. The {@code protoBuilder} argument contains policies
+   * code within the call. The {@link RelOptRule#relBuilderFactory} argument contains policies
    * such as what implementation of {@link Filter} to create. */
-  public RelBuilder builder(RelBuilder.ProtoRelBuilder protoBuilder) {
-    return protoBuilder.create(rel(0).getCluster(), null);
+  public RelBuilder builder() {
+    return rule.relBuilderFactory.create(rel(0).getCluster(), null);
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/rel/core/RelFactories.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/RelFactories.java
@@ -39,6 +39,7 @@ import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBitSet;
 
 import com.google.common.collect.ImmutableList;
@@ -77,10 +78,9 @@ public class RelFactories {
   public static final TableScanFactory DEFAULT_TABLE_SCAN_FACTORY =
       new TableScanFactoryImpl();
 
-  /** Creates a {@link RelBuilder} that will create logical relational
-   * expressions for everything.
-   */
-  public static final RelBuilder.ProtoRelBuilder DEFAULT_PROTO =
+  /** A {@link RelBuilderFactory} that creates a {@link RelBuilder} that will
+   * create logical relational expressions for everything. */
+  public static final RelBuilderFactory LOGICAL_BUILDER =
       RelBuilder.proto(
           Contexts.of(DEFAULT_PROJECT_FACTORY,
               DEFAULT_FILTER_FACTORY,

--- a/core/src/main/java/org/apache/calcite/rel/core/TableScan.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/TableScan.java
@@ -31,6 +31,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.ImmutableIntList;
 
@@ -116,9 +117,9 @@ public abstract class TableScan extends AbstractRelNode {
    * fields that were not included in the table's official type.
    *
    * <p>The default implementation assumes that tables cannot do either of
-   * these operations, therefore it adds a
-   * {@link org.apache.calcite.rel.logical.LogicalProject}, projecting
-   * {@code NULL} values for the extra fields.</p>
+   * these operations, therefore it adds a {@link Project} that projects
+   * {@code NULL} values for the extra fields, using the
+   * {@link RelBuilder#project(Iterable)} method.
    *
    * <p>Sub-classes, representing table types that have these capabilities,
    * should override.</p>
@@ -126,19 +127,20 @@ public abstract class TableScan extends AbstractRelNode {
    * @param fieldsUsed  Bitmap of the fields desired by the consumer
    * @param extraFields Extra fields, not advertised in the table's row-type,
    *                    wanted by the consumer
+   * @param relBuilder Builder used to create a Project
    * @return Relational expression that projects the desired fields
    */
   public RelNode project(ImmutableBitSet fieldsUsed,
       Set<RelDataTypeField> extraFields,
-      RelFactories.ProjectFactory projectFactory) {
+      RelBuilder relBuilder) {
     final int fieldCount = getRowType().getFieldCount();
     if (fieldsUsed.equals(ImmutableBitSet.range(fieldCount))
         && extraFields.isEmpty()) {
       return this;
     }
-    List<RexNode> exprList = new ArrayList<RexNode>();
-    List<String> nameList = new ArrayList<String>();
-    RexBuilder rexBuilder = getCluster().getRexBuilder();
+    final List<RexNode> exprList = new ArrayList<>();
+    final List<String> nameList = new ArrayList<>();
+    final RexBuilder rexBuilder = getCluster().getRexBuilder();
     final List<RelDataTypeField> fields = getRowType().getFieldList();
 
     // Project the subset of fields.
@@ -159,7 +161,7 @@ public abstract class TableScan extends AbstractRelNode {
       nameList.add(extraField.getName());
     }
 
-    return projectFactory.createProject(this, exprList, nameList);
+    return relBuilder.push(this).project(exprList, nameList).build();
   }
 
   @Override public RelNode accept(RelShuttle shuttle) {

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalWindow.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalWindow.java
@@ -34,6 +34,7 @@ import org.apache.calcite.rex.RexProgram;
 import org.apache.calcite.rex.RexShuttle;
 import org.apache.calcite.rex.RexWindow;
 import org.apache.calcite.rex.RexWindowBound;
+import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Pair;
 
@@ -99,10 +100,8 @@ public final class LogicalWindow extends Window {
   /**
    * Creates a LogicalWindow by parsing a {@link RexProgram}.
    */
-  public static RelNode create(
-      RelOptCluster cluster,
-      RelTraitSet traitSet,
-      RelNode child,
+  public static RelNode create(RelOptCluster cluster,
+      RelTraitSet traitSet, RelBuilder relBuilder, RelNode child,
       final RexProgram program) {
     final RelDataType outRowType = program.getOutputRowType();
     // Build a list of distinct groups, partitions and aggregate
@@ -277,10 +276,9 @@ public final class LogicalWindow extends Window {
       projectList.add(ref);
     }
 
-    return RelOptUtil.createProject(
-        window,
-        projectList,
-        outRowType.getFieldNames());
+    return relBuilder.push(window)
+        .project(projectList, outRowType.getFieldNames())
+        .build();
   }
 
   private static List<RexNode> toInputRefs(

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateRemoveRule.java
@@ -18,9 +18,9 @@ package org.apache.calcite.rel.rules;
 
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
-import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.tools.RelBuilder;
 
 /**
  * Planner rule that removes
@@ -67,15 +67,13 @@ public class AggregateRemoveRule extends RelOptRule {
 
     // If aggregate was projecting a subset of columns, add a project for the
     // same effect.
-    RelNode rel;
+    final RelBuilder relBuilder = call.builder();
+    relBuilder.push(newInput);
     if (newInput.getRowType().getFieldCount()
         > aggregate.getRowType().getFieldCount()) {
-      rel = RelOptUtil.createProject(newInput,
-          aggregate.getGroupSet().toList());
-    } else {
-      rel = newInput;
+      relBuilder.project(relBuilder.fields(aggregate.getGroupSet().toList()));
     }
-    call.transformTo(rel);
+    call.transformTo(relBuilder.build());
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/rel/rules/FilterAggregateTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/FilterAggregateTransposeRule.java
@@ -28,6 +28,7 @@ import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBitSet;
 
 import com.google.common.collect.ImmutableList;
@@ -48,10 +49,8 @@ public class FilterAggregateTransposeRule extends RelOptRule {
    *
    * <p>It matches any kind of agg. or filter */
   public static final FilterAggregateTransposeRule INSTANCE =
-      new FilterAggregateTransposeRule(Filter.class, RelFactories.DEFAULT_PROTO,
-          Aggregate.class);
-
-  private final RelBuilder.ProtoRelBuilder protoBuilder;
+      new FilterAggregateTransposeRule(Filter.class,
+          RelFactories.LOGICAL_BUILDER, Aggregate.class);
 
   //~ Constructors -----------------------------------------------------------
 
@@ -63,12 +62,12 @@ public class FilterAggregateTransposeRule extends RelOptRule {
    */
   public FilterAggregateTransposeRule(
       Class<? extends Filter> filterClass,
-      RelBuilder.ProtoRelBuilder protoBuilder,
+      RelBuilderFactory builderFactory,
       Class<? extends Aggregate> aggregateClass) {
     super(
         operand(filterClass,
-            operand(aggregateClass, any())));
-    this.protoBuilder = protoBuilder;
+            operand(aggregateClass, any())),
+        builderFactory, null);
   }
 
   @Deprecated // to be removed before 2.0
@@ -108,7 +107,7 @@ public class FilterAggregateTransposeRule extends RelOptRule {
       }
     }
 
-    final RelBuilder builder = call.builder(protoBuilder);
+    final RelBuilder builder = call.builder();
     RelNode rel =
         builder.push(aggRel.getInput()).filter(pushedConditions).build();
     if (rel == aggRel.getInput(0)) {

--- a/core/src/main/java/org/apache/calcite/rel/rules/JoinPushThroughJoinRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/JoinPushThroughJoinRule.java
@@ -30,6 +30,8 @@ import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexPermuteInputsShuttle;
 import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.mapping.Mappings;
 
@@ -65,31 +67,34 @@ public class JoinPushThroughJoinRule extends RelOptRule {
   public static final RelOptRule RIGHT =
       new JoinPushThroughJoinRule(
           "JoinPushThroughJoinRule:right", true, LogicalJoin.class,
-          RelFactories.DEFAULT_PROJECT_FACTORY);
+          RelFactories.LOGICAL_BUILDER);
 
   /** Instance of the rule that works on logical joins only, and pushes to the
    * left. */
   public static final RelOptRule LEFT =
       new JoinPushThroughJoinRule(
           "JoinPushThroughJoinRule:left", false, LogicalJoin.class,
-          RelFactories.DEFAULT_PROJECT_FACTORY);
+          RelFactories.LOGICAL_BUILDER);
 
   private final boolean right;
-
-  private final ProjectFactory projectFactory;
 
   /**
    * Creates a JoinPushThroughJoinRule.
    */
   public JoinPushThroughJoinRule(String description, boolean right,
-      Class<? extends Join> clazz, ProjectFactory projectFactory) {
+      Class<? extends Join> clazz, RelBuilderFactory relBuilderFactory) {
     super(
         operand(clazz,
             operand(clazz, any()),
             operand(RelNode.class, any())),
-        description);
+        relBuilderFactory, description);
     this.right = right;
-    this.projectFactory = projectFactory;
+  }
+
+  @Deprecated // to be removed before 2.0
+  public JoinPushThroughJoinRule(String description, boolean right,
+      Class<? extends Join> clazz, ProjectFactory projectFactory) {
+    this(description, right, clazz, RelBuilder.proto(projectFactory));
   }
 
   @Override public void onMatch(RelOptRuleCall call) {
@@ -137,8 +142,8 @@ public class JoinPushThroughJoinRule extends RelOptRule {
 
     // Split the condition of topJoin into a conjunction. Each of the
     // parts that does not use columns from B can be pushed down.
-    final List<RexNode> intersecting = new ArrayList<RexNode>();
-    final List<RexNode> nonIntersecting = new ArrayList<RexNode>();
+    final List<RexNode> intersecting = new ArrayList<>();
+    final List<RexNode> nonIntersecting = new ArrayList<>();
     split(topJoin.getCondition(), bBitSet, intersecting, nonIntersecting);
 
     // If there's nothing to push down, it's not worth proceeding.
@@ -148,8 +153,8 @@ public class JoinPushThroughJoinRule extends RelOptRule {
 
     // Split the condition of bottomJoin into a conjunction. Each of the
     // parts that use columns from B will need to be pulled up.
-    final List<RexNode> bottomIntersecting = new ArrayList<RexNode>();
-    final List<RexNode> bottomNonIntersecting = new ArrayList<RexNode>();
+    final List<RexNode> bottomIntersecting = new ArrayList<>();
+    final List<RexNode> bottomNonIntersecting = new ArrayList<>();
     split(
         bottomJoin.getCondition(), bBitSet, bottomIntersecting,
         bottomNonIntersecting);
@@ -161,7 +166,7 @@ public class JoinPushThroughJoinRule extends RelOptRule {
             aCount + bCount + cCount,
             0, 0, aCount,
             aCount, aCount + bCount, cCount);
-    List<RexNode> newBottomList = new ArrayList<RexNode>();
+    final List<RexNode> newBottomList = new ArrayList<>();
     new RexPermuteInputsShuttle(bottomMapping, relA, relC)
         .visitList(nonIntersecting, newBottomList);
     final Mappings.TargetMapping bottomBottomMapping =
@@ -185,7 +190,7 @@ public class JoinPushThroughJoinRule extends RelOptRule {
             0, 0, aCount,
             aCount + cCount, aCount, bCount,
             aCount, aCount + bCount, cCount);
-    List<RexNode> newTopList = new ArrayList<RexNode>();
+    final List<RexNode> newTopList = new ArrayList<>();
     new RexPermuteInputsShuttle(topMapping, newBottomJoin, relB)
         .visitList(intersecting, newTopList);
     new RexPermuteInputsShuttle(topMapping, newBottomJoin, relB)
@@ -198,10 +203,10 @@ public class JoinPushThroughJoinRule extends RelOptRule {
             relB, topJoin.getJoinType(), topJoin.isSemiJoinDone());
 
     assert !Mappings.isIdentity(topMapping);
-    final RelNode newProject = RelOptUtil.createProject(projectFactory,
-        newTopJoin, Mappings.asList(topMapping));
-
-    call.transformTo(newProject);
+    final RelBuilder relBuilder = call.builder();
+    relBuilder.push(newTopJoin);
+    relBuilder.project(relBuilder.fields(topMapping));
+    call.transformTo(relBuilder.build());
   }
 
   /**
@@ -244,8 +249,8 @@ public class JoinPushThroughJoinRule extends RelOptRule {
 
     // Split the condition of topJoin into a conjunction. Each of the
     // parts that does not use columns from A can be pushed down.
-    final List<RexNode> intersecting = new ArrayList<RexNode>();
-    final List<RexNode> nonIntersecting = new ArrayList<RexNode>();
+    final List<RexNode> intersecting = new ArrayList<>();
+    final List<RexNode> nonIntersecting = new ArrayList<>();
     split(topJoin.getCondition(), aBitSet, intersecting, nonIntersecting);
 
     // If there's nothing to push down, it's not worth proceeding.
@@ -255,8 +260,8 @@ public class JoinPushThroughJoinRule extends RelOptRule {
 
     // Split the condition of bottomJoin into a conjunction. Each of the
     // parts that use columns from B will need to be pulled up.
-    final List<RexNode> bottomIntersecting = new ArrayList<RexNode>();
-    final List<RexNode> bottomNonIntersecting = new ArrayList<RexNode>();
+    final List<RexNode> bottomIntersecting = new ArrayList<>();
+    final List<RexNode> bottomNonIntersecting = new ArrayList<>();
     split(
         bottomJoin.getCondition(), aBitSet, bottomIntersecting,
         bottomNonIntersecting);
@@ -268,7 +273,7 @@ public class JoinPushThroughJoinRule extends RelOptRule {
             aCount + bCount + cCount,
             cCount, aCount, bCount,
             0, aCount + bCount, cCount);
-    List<RexNode> newBottomList = new ArrayList<RexNode>();
+    final List<RexNode> newBottomList = new ArrayList<>();
     new RexPermuteInputsShuttle(bottomMapping, relC, relB)
         .visitList(nonIntersecting, newBottomList);
     final Mappings.TargetMapping bottomBottomMapping =
@@ -293,7 +298,7 @@ public class JoinPushThroughJoinRule extends RelOptRule {
             cCount + bCount, 0, aCount,
             cCount, aCount, bCount,
             0, aCount + bCount, cCount);
-    List<RexNode> newTopList = new ArrayList<RexNode>();
+    final List<RexNode> newTopList = new ArrayList<>();
     new RexPermuteInputsShuttle(topMapping, newBottomJoin, relA)
         .visitList(intersecting, newTopList);
     new RexPermuteInputsShuttle(topMapping, newBottomJoin, relA)
@@ -305,10 +310,10 @@ public class JoinPushThroughJoinRule extends RelOptRule {
         topJoin.copy(topJoin.getTraitSet(), newTopCondition, newBottomJoin,
             relA, topJoin.getJoinType(), topJoin.isSemiJoinDone());
 
-    final RelNode newProject = RelOptUtil.createProject(projectFactory,
-        newTopJoin, Mappings.asList(topMapping));
-
-    call.transformTo(newProject);
+    final RelBuilder relBuilder = call.builder();
+    relBuilder.push(newTopJoin);
+    relBuilder.project(relBuilder.fields(topMapping));
+    call.transformTo(relBuilder.build());
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/rules/JoinToCorrelateRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/JoinToCorrelateRule.java
@@ -16,10 +16,10 @@
  */
 package org.apache.calcite.rel.rules;
 
+import org.apache.calcite.plan.Contexts;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
-import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.RelFactories;
@@ -29,8 +29,9 @@ import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexShuttle;
-import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.SemiJoinType;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Util;
 
@@ -60,19 +61,20 @@ public class JoinToCorrelateRule extends RelOptRule {
   //~ Static fields/initializers ---------------------------------------------
 
   public static final JoinToCorrelateRule INSTANCE =
-      new JoinToCorrelateRule(RelFactories.DEFAULT_FILTER_FACTORY);
-
-  protected final RelFactories.FilterFactory filterFactory;
+      new JoinToCorrelateRule(RelFactories.LOGICAL_BUILDER);
 
   //~ Constructors -----------------------------------------------------------
 
   /**
    * Private constructor; use singleton {@link #INSTANCE}.
    */
+  protected JoinToCorrelateRule(RelBuilderFactory relBuilderFactory) {
+    super(operand(LogicalJoin.class, any()), relBuilderFactory, null);
+  }
+
+  @Deprecated // to be removed before 2.0
   protected JoinToCorrelateRule(RelFactories.FilterFactory filterFactory) {
-    super(operand(LogicalJoin.class, any()));
-    this.filterFactory = filterFactory;
-    assert filterFactory != null : "Filter factory should not be null";
+    this(RelBuilder.proto(Contexts.of(filterFactory)));
   }
 
   //~ Methods ----------------------------------------------------------------
@@ -99,15 +101,15 @@ public class JoinToCorrelateRule extends RelOptRule {
     final int leftFieldCount = left.getRowType().getFieldCount();
     final RelOptCluster cluster = join.getCluster();
     final RexBuilder rexBuilder = cluster.getRexBuilder();
+    final RelBuilder relBuilder = call.builder();
     final int dynInId = cluster.createCorrel();
     final CorrelationId correlationId = new CorrelationId(dynInId);
     final RexNode corrVar =
         rexBuilder.makeCorrel(left.getRowType(), correlationId.getName());
     final ImmutableBitSet.Builder requiredColumns = ImmutableBitSet.builder();
-    RexNode joinCondition = join.getCondition();
 
     // Replace all references of left input with FieldAccess(corrVar, field)
-    joinCondition = joinCondition.accept(new RexShuttle() {
+    final RexNode joinCondition = join.getCondition().accept(new RexShuttle() {
       @Override public RexNode visitInputRef(RexInputRef input) {
         int field = input.getIndex();
         if (field >= leftFieldCount) {
@@ -119,12 +121,11 @@ public class JoinToCorrelateRule extends RelOptRule {
       }
     });
 
-    joinCondition = RexUtil.flatten(rexBuilder, joinCondition);
-    final RelNode filteredRight =
-        RelOptUtil.createFilter(right, joinCondition, filterFactory);
+    relBuilder.push(right).filter(joinCondition);
+
     RelNode newRel =
         LogicalCorrelate.create(left,
-            filteredRight,
+            relBuilder.build(),
             correlationId,
             requiredColumns.build(),
             SemiJoinType.of(join.getJoinType()));

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectSortTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectSortTransposeRule.java
@@ -19,14 +19,14 @@ package org.apache.calcite.rel.rules;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.Sort;
-import org.apache.calcite.rel.logical.LogicalProject;
 
 import com.google.common.collect.ImmutableList;
 
 /**
  * Planner rule that pushes
- * a {@link org.apache.calcite.rel.logical.LogicalProject}
+ * a {@link org.apache.calcite.rel.core.Project}
  * past a {@link org.apache.calcite.rel.core.Sort}.
  *
  * @see org.apache.calcite.rel.rules.SortProjectTransposeRule
@@ -42,15 +42,15 @@ public class ProjectSortTransposeRule extends RelOptRule {
    */
   private ProjectSortTransposeRule() {
     super(
-        operand(LogicalProject.class,
+        operand(Project.class,
             operand(Sort.class, any())));
   }
 
   //~ Methods ----------------------------------------------------------------
 
   public void onMatch(RelOptRuleCall call) {
-    LogicalProject project = call.rel(0);
-    Sort sort = call.rel(1);
+    final Project project = call.rel(0);
+    final Sort sort = call.rel(1);
     if (sort.getClass() != Sort.class) {
       return;
     }

--- a/core/src/main/java/org/apache/calcite/rel/rules/SortJoinTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SortJoinTransposeRule.java
@@ -36,9 +36,10 @@ import com.google.common.collect.ImmutableList;
 
 /**
  * Planner rule that pushes a {@link org.apache.calcite.rel.core.Sort} past a
- * {@link org.apache.calcite.rel.core.Join}. At the moment, we only consider
- * left/right outer joins.
- * However, an extesion for full outer joins for this rule could be envision.
+ * {@link org.apache.calcite.rel.core.Join}.
+ *
+ * <p>At the moment, we only consider left/right outer joins.
+ * However, an extension for full outer joins for this rule could be envisioned.
  * Special attention should be paid to null values for correctness issues.
  */
 public class SortJoinTransposeRule extends RelOptRule {
@@ -59,8 +60,7 @@ public class SortJoinTransposeRule extends RelOptRule {
 
   //~ Methods ----------------------------------------------------------------
 
-  @Override
-  public boolean matches(RelOptRuleCall call) {
+  @Override public boolean matches(RelOptRuleCall call) {
     final Sort sort = call.rel(0);
     final Join join = call.rel(1);
 
@@ -95,8 +95,7 @@ public class SortJoinTransposeRule extends RelOptRule {
     return true;
   }
 
-  @Override
-  public void onMatch(RelOptRuleCall call) {
+  @Override public void onMatch(RelOptRuleCall call) {
     final Sort sort = call.rel(0);
     final Join join = call.rel(1);
 
@@ -150,8 +149,7 @@ public class SortJoinTransposeRule extends RelOptRule {
     if (rowCount != null && fetch != null) {
       final int offsetVal = offset == null ? 0 : RexLiteral.intValue(offset);
       final int limit = RexLiteral.intValue(fetch);
-      final Double offsetLimit = new Double(offsetVal + limit);
-      if (offsetLimit < rowCount) {
+      if ((double) offsetVal + (double) limit < rowCount) {
         alreadySmaller = false;
       }
     }
@@ -159,3 +157,5 @@ public class SortJoinTransposeRule extends RelOptRule {
   }
 
 }
+
+// End SortJoinTransposeRule.java

--- a/core/src/main/java/org/apache/calcite/rel/rules/SortProjectTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SortProjectTransposeRule.java
@@ -24,6 +24,7 @@ import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelCollationTraitDef;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rex.RexUtil;
@@ -37,7 +38,7 @@ import java.util.Map;
 /**
  * Planner rule that pushes
  * a {@link org.apache.calcite.rel.core.Sort}
- * past a {@link org.apache.calcite.rel.logical.LogicalProject}.
+ * past a {@link org.apache.calcite.rel.core.Project}.
  *
  * @see org.apache.calcite.rel.rules.ProjectSortTransposeRule
  */
@@ -52,17 +53,15 @@ public class SortProjectTransposeRule extends RelOptRule {
    */
   private SortProjectTransposeRule() {
     super(
-        operand(
-            Sort.class,
+        operand(Sort.class,
             operand(LogicalProject.class, any())));
   }
 
   //~ Methods ----------------------------------------------------------------
 
-  // implement RelOptRule
   public void onMatch(RelOptRuleCall call) {
     final Sort sort = call.rel(0);
-    final LogicalProject project = call.rel(1);
+    final Project project = call.rel(1);
     final RelOptCluster cluster = project.getCluster();
 
     if (sort.getConvention() != project.getConvention()) {

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -142,6 +142,7 @@ import org.apache.calcite.sql.validate.SqlValidatorImpl;
 import org.apache.calcite.sql.validate.SqlValidatorNamespace;
 import org.apache.calcite.sql.validate.SqlValidatorScope;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
+import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.ImmutableIntList;
 import org.apache.calcite.util.NlsString;
@@ -543,7 +544,9 @@ public class SqlToRelConverter {
    * @return Field trimmer
    */
   protected RelFieldTrimmer newFieldTrimmer() {
-    return new RelFieldTrimmer(validator);
+    final RelBuilder relBuilder =
+        RelFactories.LOGICAL_BUILDER.create(cluster, null);
+    return new RelFieldTrimmer(validator, relBuilder);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilderFactory.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilderFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.tools;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptSchema;
+import org.apache.calcite.rel.core.RelFactories;
+
+/** A partially-created RelBuilder.
+ *
+ * <p>Add a cluster, and optionally a schema,
+ * when you want to create a builder.
+ *
+ * <p>A {@code ProtoRelBuilder} can be shared among queries, and thus can
+ * be inside a {@link RelOptRule}. It is a nice way to encapsulate the policy
+ * that this particular rule instance should create {@code DrillFilter}
+ * and {@code DrillProject} versus {@code HiveFilter} and {@code HiveProject}.
+ *
+ * @see RelFactories#LOGICAL_BUILDER
+ */
+public interface RelBuilderFactory {
+  /** Creates a RelBuilder. */
+  RelBuilder create(RelOptCluster cluster, RelOptSchema schema);
+}
+
+// End RelBuilderFactory.java

--- a/core/src/test/java/org/apache/calcite/test/JdbcAdapterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcAdapterTest.java
@@ -206,7 +206,7 @@ public class JdbcAdapterTest {
             + "FROM \"SCOTT\".\"EMP\") AS \"t0\" ON \"t\".\"MGR\" = \"t0\".\"EMPNO\" AND (\"t\".\"SAL\" > \"t0\".\"SAL\" OR \"t\".\"HIREDATE\" < \"t0\".\"HIREDATE\")");
   }
 
-  @Test public void tesJoin3TablesPlan() {
+  @Test public void testJoin3TablesPlan() {
     CalciteAssert.model(JdbcTest.SCOTT_MODEL)
         .query("select  empno, ename, dname, grade \n"
             + "from scott.emp e inner join scott.dept d \n"

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelTestBase.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelTestBase.java
@@ -31,6 +31,7 @@ import org.apache.calcite.rel.RelDistributions;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelRoot;
+import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.rel.logical.LogicalTableScan;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -51,6 +52,7 @@ import org.apache.calcite.sql.validate.SqlValidatorTable;
 import org.apache.calcite.sql2rel.RelFieldTrimmer;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.sql2rel.StandardConvertletTable;
+import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Util;
 
@@ -598,7 +600,9 @@ public abstract class SqlToRelTestBase {
       assertValid(rel);
 
       if (trim) {
-        final RelFieldTrimmer trimmer = createFieldTrimmer();
+        final RelBuilder relBuilder =
+            RelFactories.LOGICAL_BUILDER.create(rel.getCluster(), null);
+        final RelFieldTrimmer trimmer = createFieldTrimmer(relBuilder);
         rel = trimmer.trim(rel);
         assertTrue(rel != null);
         assertValid(rel);
@@ -614,10 +618,11 @@ public abstract class SqlToRelTestBase {
     /**
      * Creates a RelFieldTrimmer.
      *
+     * @param relBuilder Builder
      * @return Field trimmer
      */
-    public RelFieldTrimmer createFieldTrimmer() {
-      return new RelFieldTrimmer(getValidator());
+    public RelFieldTrimmer createFieldTrimmer(RelBuilder relBuilder) {
+      return new RelFieldTrimmer(getValidator(), relBuilder);
     }
 
     /**

--- a/core/src/test/java/org/apache/calcite/tools/PlannerTest.java
+++ b/core/src/test/java/org/apache/calcite/tools/PlannerTest.java
@@ -639,11 +639,10 @@ public class PlannerTest {
             + "  EnumerableProject(empid=[$2], deptno=[$3], name=[$4], salary=[$5], commission=[$6], deptno0=[$7], name0=[$8], employees=[$9], x=[$10], y=[$11], empid0=[$0], name1=[$1])\n"
             + "    EnumerableJoin(condition=[=($0, $2)], joinType=[inner])\n"
             + "      EnumerableTableScan(table=[[hr, dependents]])\n"
-            + "      EnumerableProject(empid=[$0], deptno=[$1], name=[$2], salary=[$3], commission=[$4], deptno0=[$5], name0=[$6], employees=[$7], x=[$8], y=[$9])\n"
-            + "        EnumerableJoin(condition=[=($1, $5)], joinType=[left])\n"
-            + "          EnumerableTableScan(table=[[hr, emps]])\n"
-            + "          EnumerableProject(deptno=[$0], name=[$1], employees=[$2], x=[$3.x], y=[$3.y])\n"
-            + "            EnumerableTableScan(table=[[hr, depts]])");
+            + "      EnumerableJoin(condition=[=($1, $5)], joinType=[left])\n"
+            + "        EnumerableTableScan(table=[[hr, emps]])\n"
+            + "        EnumerableProject(deptno=[$0], name=[$1], employees=[$2], x=[$3.x], y=[$3.y])\n"
+            + "          EnumerableTableScan(table=[[hr, depts]])");
   }
 
   /** It would probably be OK to transform
@@ -679,11 +678,10 @@ public class PlannerTest {
             + "  EnumerableProject(empid=[$2], deptno=[$3], name=[$4], salary=[$5], commission=[$6], deptno0=[$7], name0=[$8], employees=[$9], x=[$10], y=[$11], empid0=[$0], name1=[$1])\n"
             + "    EnumerableJoin(condition=[=($0, $2)], joinType=[left])\n"
             + "      EnumerableTableScan(table=[[hr, dependents]])\n"
-            + "      EnumerableProject(empid=[$0], deptno=[$1], name=[$2], salary=[$3], commission=[$4], deptno0=[$5], name0=[$6], employees=[$7], x=[$8], y=[$9])\n"
-            + "        EnumerableJoin(condition=[=($1, $5)], joinType=[inner])\n"
-            + "          EnumerableTableScan(table=[[hr, emps]])\n"
-            + "          EnumerableProject(deptno=[$0], name=[$1], employees=[$2], x=[$3.x], y=[$3.y])\n"
-            + "            EnumerableTableScan(table=[[hr, depts]])");
+            + "      EnumerableJoin(condition=[=($1, $5)], joinType=[inner])\n"
+            + "        EnumerableTableScan(table=[[hr, emps]])\n"
+            + "        EnumerableProject(deptno=[$0], name=[$1], employees=[$2], x=[$3.x], y=[$3.y])\n"
+            + "          EnumerableTableScan(table=[[hr, depts]])");
   }
 
   private void checkHeuristic(String sql, String expected) throws Exception {

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -428,10 +428,9 @@ LogicalAggregate(group=[{0}], EXPR$1=[MAX($0)], EXPR$2=[AVG($1)], EXPR$3=[MIN($0
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(NAME=[$0], EXPR$1=[$1], EXPR$2=[CAST(/($2, $3)):INTEGER NOT NULL], EXPR$3=[$4])
-  LogicalProject(NAME=[$0], EXPR$1=[$1], $f2=[$2], $f3=[$3], EXPR$3=[$4])
-    LogicalAggregate(group=[{0}], EXPR$1=[MAX($0)], agg#1=[$SUM0($1)], agg#2=[COUNT()], EXPR$3=[MIN($0)])
-      LogicalProject(NAME=[$1], DEPTNO=[$0])
-        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+  LogicalAggregate(group=[{0}], EXPR$1=[MAX($0)], agg#1=[$SUM0($1)], agg#2=[COUNT()], EXPR$3=[MIN($0)])
+    LogicalProject(NAME=[$1], DEPTNO=[$0])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
         </Resource>
     </TestCase>
@@ -753,9 +752,9 @@ LogicalProject(EXPR$0=[CAST($1):VARCHAR(128) CHARACTER SET "ISO-8859-1" COLLATE 
   LogicalFilter(condition=[=(CAST(CAST($4):VARCHAR(1) CHARACTER SET "ISO-8859-1" COLLATE "ISO-8859-1$en_US$primary" NOT NULL):VARCHAR(7) CHARACTER SET "ISO-8859-1" COLLATE "ISO-8859-1$en_US$primary" NOT NULL, 'Manager')])
     LogicalProject(DEPTNO=[$0], NAME=[$1], EMPNO=[$3], ENAME=[$4], JOB=[$5], MGR=[$6], HIREDATE=[$7], SAL=[$8], COMM=[$9], DEPTNO0=[$10], SLACKER=[$11])
       LogicalJoin(condition=[=($2, $12)], joinType=[inner])
-        LogicalProject(DEPTNO=[$0], NAME=[$1], $f2=[CAST($0):INTEGER NOT NULL])
+        LogicalProject(DEPTNO=[$0], NAME=[$1], DEPTNO2=[CAST($0):INTEGER NOT NULL])
           LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
-        LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], $f9=[CAST($7):INTEGER NOT NULL])
+        LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO9=[CAST($7):INTEGER NOT NULL])
           LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
@@ -765,9 +764,9 @@ LogicalProject(EXPR$0=[CAST($1):VARCHAR(128) CHARACTER SET "ISO-8859-1" COLLATE 
   LogicalFilter(condition=[=(CAST(CAST($4):VARCHAR(1) CHARACTER SET "ISO-8859-1" COLLATE "ISO-8859-1$en_US$primary" NOT NULL):VARCHAR(7) CHARACTER SET "ISO-8859-1" COLLATE "ISO-8859-1$en_US$primary" NOT NULL, 'Manager')])
     LogicalProject(DEPTNO=[$0], NAME=[$1], EMPNO=[$3], ENAME=[$4], JOB=[$5], MGR=[$6], HIREDATE=[$7], SAL=[$8], COMM=[$9], DEPTNO0=[$10], SLACKER=[$11])
       LogicalJoin(condition=[=($2, $12)], joinType=[inner])
-        LogicalProject(DEPTNO=[$0], NAME=[$1], $f2=[$0])
+        LogicalProject(DEPTNO=[$0], NAME=[$1], DEPTNO2=[$0])
           LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
-        LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], $f9=[$7])
+        LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO9=[$7])
           LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
@@ -3216,9 +3215,8 @@ LogicalProject(DEPTNO=[$0], JOB=[$1], EXPR$2=[$4])
 LogicalProject(DEPTNO=[CASE($2, null, $0)], JOB=[CASE($3, null, $1)], EXPR$2=[$4])
   LogicalAggregate(group=[{0, 1}], indicator=[true], EXPR$2=[COUNT($2)])
     LogicalAggregate(group=[{0, 1, 2}])
-      LogicalProject(DEPTNO=[$0], JOB=[$1], ENAME=[$2])
-        LogicalProject(DEPTNO=[$7], JOB=[$2], ENAME=[$1])
-          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalProject(DEPTNO=[$7], JOB=[$2], ENAME=[$1])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>
@@ -3617,8 +3615,8 @@ LogicalProject(EMPNO=[$0], EXPR$1=[$2])
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(EMPNO=[$0], EXPR$1=[$2])
-  LogicalProject($f0=[$0], $f1=[$2], $f2=[$4])
-    LogicalProject($f0=[$0], $f1=[$1], $f2=[$2], $f3=[$3], $f4=[CAST(*($1, $3)):INTEGER NOT NULL])
+  LogicalProject(EMPNO=[$0], DEPTNO=[$2], $f4=[$4])
+    LogicalProject(EMPNO=[$0], EXPR$1=[$1], DEPTNO=[$2], $f1=[$3], $f4=[CAST(*($1, $3)):INTEGER NOT NULL])
       LogicalJoin(condition=[=($0, $2)], joinType=[inner])
         LogicalAggregate(group=[{0}], EXPR$1=[SUM($5)])
           LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
@@ -3976,8 +3974,8 @@ LogicalProject(EMPNO=[$0], MIN_SAL=[$2], MIN_DEPTNO=[$3], SUM_SAL_PLUS=[+($4, 1)
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(EMPNO=[$0], MIN_SAL=[$2], MIN_DEPTNO=[$3], SUM_SAL_PLUS=[+($4, 1)], MAX_SAL=[$5], SUM_SAL_2=[$4], COUNT_SAL=[$6], COUNT_MGR=[$7])
-  LogicalProject($f0=[$0], $f1=[$7], $f2=[$1], $f3=[$2], $f4=[$9], $f5=[$4], $f6=[$10], $f7=[$11])
-    LogicalProject($f0=[$0], $f1=[$1], $f2=[$2], $f3=[$3], $f4=[$4], $f5=[$5], $f6=[$6], $f7=[$7], $f8=[$8], $f9=[CAST(*($3, $8)):INTEGER NOT NULL], $f10=[*($5, $8)], $f11=[*($6, $8)])
+  LogicalProject(EMPNO=[$0], DEPTNO=[$7], MIN_SAL=[$1], MIN_DEPTNO=[$2], $f9=[$9], MAX_SAL=[$4], $f10=[$10], $f11=[$11])
+    LogicalProject(EMPNO=[$0], MIN_SAL=[$1], MIN_DEPTNO=[$2], SUM_SAL_2=[$3], MAX_SAL=[$4], COUNT_SAL=[$5], COUNT_MGR=[$6], DEPTNO=[$7], $f1=[$8], $f9=[CAST(*($3, $8)):INTEGER NOT NULL], $f10=[*($5, $8)], $f11=[*($6, $8)])
       LogicalJoin(condition=[=($0, $7)], joinType=[inner])
         LogicalAggregate(group=[{0}], MIN_SAL=[MIN($5)], MIN_DEPTNO=[MIN($7)], SUM_SAL_2=[SUM($5)], MAX_SAL=[MAX($5)], COUNT_SAL=[COUNT()], COUNT_MGR=[COUNT($3)])
           LogicalTableScan(table=[[CATALOG, SALES, EMP]])
@@ -4001,7 +3999,7 @@ LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
         <Resource name="planAfter">
             <![CDATA[
 LogicalAggregate(group=[{}], EXPR$0=[$SUM0($4)])
-  LogicalProject($f0=[$0], $f1=[$1], $f2=[$2], $f3=[$3], $f4=[*($1, $3)])
+  LogicalProject(DEPTNO=[$0], EXPR$0=[$1], DEPTNO0=[$2], EXPR$00=[$3], $f4=[*($1, $3)])
     LogicalJoin(condition=[=($0, $2)], joinType=[inner])
       LogicalAggregate(group=[{7}], EXPR$0=[COUNT()])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
@@ -4030,7 +4028,7 @@ LogicalAggregate(group=[{9}], SUM_SAL=[SUM($5)], C=[COUNT()])
         </Resource>
         <Resource name="planAfter">
             <![CDATA[
-LogicalProject($f0=[$3], $f1=[$1], $f2=[$2])
+LogicalProject(DEPTNO=[$3], SUM_SAL=[$1], C=[$2])
   LogicalJoin(condition=[=($0, $3)], joinType=[inner])
     LogicalAggregate(group=[{0}], SUM_SAL=[SUM($5)], C=[COUNT()])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])

--- a/mongodb/src/test/java/org/apache/calcite/test/MongoAdapterIT.java
+++ b/mongodb/src/test/java/org/apache/calcite/test/MongoAdapterIT.java
@@ -658,9 +658,9 @@ public class MongoAdapterIT {
             + "STATE=CA; CDC=1072\n")
         .queryContains(
             mongoChecker(
-                "{$project: {STATE: '$state', CITY: '$city'}}",
-                "{$group: {_id: {STATE: '$STATE', CITY: '$CITY'}}}",
-                "{$project: {_id: 0, STATE: '$_id.STATE', CITY: '$_id.CITY'}}",
+                "{$project: {CITY: '$city', STATE: '$state'}}",
+                "{$group: {_id: {CITY: '$CITY', STATE: '$STATE'}}}",
+                "{$project: {_id: 0, CITY: '$_id.CITY', STATE: '$_id.STATE'}}",
                 "{$group: {_id: '$STATE', CDC: {$sum: {$cond: [ {$eq: ['CITY', null]}, 0, 1]}}}}",
                 "{$project: {STATE: '$_id', CDC: '$CDC'}}",
                 "{$sort: {CDC: -1}}",


### PR DESCRIPTION
All rules now have a RelBuilderFactory, from which RelOptCall can
create a RelBuilder. All built-in rules that took a relational
expression factory (for example ProjectFactory) now use the RelBuilder.
We have converted some, but not all, other implicit uses of a factory.

We now recommend that any rules that are generic have a
RelBuilderFactory constructor parameter, but we have not changed
existing rules to implement this policy. People will need to adapt
rules and write tests to ensure the rules are generic.

Add various methods to RelBuilder.

Mostly we add new rule constructors and deprecate the old constructor.
But a few breaking changes:
* Rename ProtoRelBuilder to RelBuilderFactory;
* Rename DEFAULT_PROTO to LOGICAL_BUILDER;
* Change signature of TableScan.project method;
* Change signature of RelFieldTrimmer constructor;
* Add filter argument to RelBuilder.aggregateCall method.

Also, not an API change, but a change in behavior: RelBuilder methods
to create set operations (union, except, intersect) get their
left-to-right arguments by reading the oldest-to-newest stack elements.