### PR TITLE
DML + Execute Request

### DIFF
--- a/avatica-server/src/test/java/org/apache/calcite/avatica/RemoteDriverTest.java
+++ b/avatica-server/src/test/java/org/apache/calcite/avatica/RemoteDriverTest.java
@@ -342,6 +342,28 @@ public class RemoteDriverTest {
   }
 
 
+  @Test public void testInsertDrop() throws Exception {
+    final String create = "create table if not exists TEST_TABLE2 ("
+        + "id int not null, "
+        + "msg varchar(3) not null)";
+    final String insert = "insert into TEST_TABLE2 values(1, 'foo')";
+    Connection connection = ljs();
+    Statement statement = connection.createStatement();
+    statement.execute(create);
+
+    Statement stmt = connection.createStatement();
+    int count = stmt.executeUpdate(insert);
+    assertTrue(count == 1);
+    ResultSet resultSet = stmt.getResultSet();
+    assertTrue(resultSet == null);
+
+    PreparedStatement pstmt = connection.prepareStatement(insert);
+    boolean status = pstmt.execute();
+    assertFalse(status);
+    int updateCount = pstmt.getUpdateCount();
+    assertTrue(updateCount == 1);
+  }
+
   private void checkStatementExecuteQuery(Connection connection,
       boolean prepare) throws SQLException {
     final String sql = "select * from (\n"
@@ -393,7 +415,8 @@ public class RemoteDriverTest {
       // PreparedStatement needed an extra fetch, as the execute will
       // trigger the 1st fetch. Where statement execute will execute direct
       // with results back.
-      checkExecuteFetch(getLocalConnection(), sql, true, 2);
+      // 1 fetch, because execute did the first fetch
+      checkExecuteFetch(getLocalConnection(), sql, true, 1);
     } finally {
       ConnectionSpec.getDatabaseLock().unlock();
     }
@@ -437,6 +460,19 @@ public class RemoteDriverTest {
     } finally {
       ConnectionSpec.getDatabaseLock().unlock();
     }
+  }
+
+  @Test public void testFetchSize() throws Exception {
+    Connection connection = ljs();
+
+    Statement statement = connection.createStatement();
+    statement.setFetchSize(101);
+    assertEquals(statement.getFetchSize(), 101);
+
+    PreparedStatement preparedStatement =
+        connection.prepareStatement("select * from (values (1, 'a')) as tbl1 (c1, c2)");
+    preparedStatement.setFetchSize(1);
+    assertEquals(preparedStatement.getFetchSize(), 1);
   }
 
   @Ignore("CALCITE-719: Refactor PreparedStatement to support setMaxRows")

--- a/avatica-server/src/test/java/org/apache/calcite/avatica/remote/RemoteMetaTest.java
+++ b/avatica-server/src/test/java/org/apache/calcite/avatica/remote/RemoteMetaTest.java
@@ -47,6 +47,8 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
@@ -57,6 +59,7 @@ import static org.junit.Assert.assertTrue;
 /** Tests covering {@link RemoteMeta}. */
 @RunWith(Parameterized.class)
 public class RemoteMetaTest {
+  private static final Random RANDOM = new Random();
   private static final ConnectionSpec CONNECTION_SPEC = ConnectionSpec.HSQLDB;
 
   // Keep a reference to the servers we start to clean them up after
@@ -258,6 +261,21 @@ public class RemoteMetaTest {
     } finally {
       ConnectionSpec.getDatabaseLock().unlock();
     }
+  }
+
+  @Test public void testRemoteStatementInsert() throws Exception {
+    System.out.println(url);
+    AvaticaConnection conn = (AvaticaConnection) DriverManager.getConnection(url);
+    Statement statement = conn.createStatement();
+    int status = statement.executeUpdate(
+        "create table if not exists "
+        + "TEST_TABLE2 (id int not null, msg varchar(255) not null)");
+    assertEquals(status, 0);
+
+    statement = conn.createStatement();
+    status = statement.executeUpdate("insert into TEST_TABLE2 values ("
+        + "'" + RANDOM.nextInt(Integer.MAX_VALUE) + "', '" + UUID.randomUUID() + "')");
+    assertEquals(status, 1);
   }
 }
 

--- a/avatica/src/main/java/org/apache/calcite/avatica/AvaticaStatement.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/AvaticaStatement.java
@@ -58,9 +58,23 @@ public abstract class AvaticaStatement
   final int resultSetType;
   final int resultSetConcurrency;
   final int resultSetHoldability;
-  private int fetchSize;
+  private int fetchSize = 100;
   private int fetchDirection;
   protected long maxRowCount = 0;
+
+  private Meta.Signature signature;
+
+  protected void setSignature(Meta.Signature signature) {
+    this.signature = signature;
+  }
+
+  protected Meta.Signature getSignature() {
+    return signature;
+  }
+
+  public Meta.StatementType getStatementType() {
+    return signature.statementType;
+  }
 
   /**
    * Creates an AvaticaStatement.
@@ -74,10 +88,17 @@ public abstract class AvaticaStatement
   protected AvaticaStatement(AvaticaConnection connection,
       Meta.StatementHandle h, int resultSetType, int resultSetConcurrency,
       int resultSetHoldability) {
+    this(connection, h, resultSetType, resultSetConcurrency, resultSetHoldability, null);
+  }
+
+  protected AvaticaStatement(AvaticaConnection connection,
+      Meta.StatementHandle h, int resultSetType, int resultSetConcurrency,
+      int resultSetHoldability, Meta.Signature signature) {
     this.connection = Objects.requireNonNull(connection);
     this.resultSetType = resultSetType;
     this.resultSetConcurrency = resultSetConcurrency;
     this.resultSetHoldability = resultSetHoldability;
+    this.signature = signature;
     this.closed = false;
     if (h == null) {
       final Meta.ConnectionHandle ch = new Meta.ConnectionHandle(connection.id);

--- a/avatica/src/main/java/org/apache/calcite/avatica/MetaImpl.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/MetaImpl.java
@@ -252,7 +252,7 @@ public abstract class MetaImpl implements Meta {
       final AvaticaStatement statement = connection.createStatement();
       final Signature signature =
           new Signature(columns, "", Collections.<AvaticaParameter>emptyList(),
-              internalParameters, cursorFactory);
+              internalParameters, cursorFactory, Meta.StatementType.SELECT);
       return MetaResultSet.create(connection.id, statement.getId(), true,
           signature, firstFrame);
     } catch (SQLException e) {
@@ -736,8 +736,7 @@ public abstract class MetaImpl implements Meta {
     return new FetchIterable(handle, firstFrame, parameterValues);
   }
 
-  public Frame fetch(StatementHandle h, List<TypedValue> parameterValues,
-      long offset, int fetchMaxRowCount) {
+  public Frame fetch(StatementHandle h, long offset, int fetchMaxRowCount) {
     return null;
   }
 
@@ -865,7 +864,7 @@ public abstract class MetaImpl implements Meta {
           rows = null;
           break;
         }
-        frame = fetch(handle, parameterValues, frame.offset, 100);
+        frame = fetch(handle, frame.offset, 100);
         parameterValues = null; // don't execute next time
         if (frame == null) {
           rows = null;
@@ -876,6 +875,20 @@ public abstract class MetaImpl implements Meta {
         rows = frame.rows.iterator();
       }
     }
+  }
+
+  /**
+   * Iterate through parameterValues to find null elements
+   */
+  public static boolean checkParameterValueHasNull(List<TypedValue> parameterValues) {
+    boolean hasNull = false;
+    for (TypedValue x : parameterValues) {
+      if (x == null) {
+        hasNull = true;
+        break;
+      }
+    }
+    return hasNull;
   }
 }
 

--- a/avatica/src/main/java/org/apache/calcite/avatica/proto/Common.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/proto/Common.java
@@ -25,6 +25,192 @@ package org.apache.calcite.avatica.proto;
       com.google.protobuf.ExtensionRegistry registry) {
   }
   /**
+   * Protobuf enum {@code StatementType}
+   *
+   * <pre>
+   * Has to be consistent with Meta.StatementType
+   * </pre>
+   */
+  public enum StatementType
+      implements com.google.protobuf.ProtocolMessageEnum {
+    /**
+     * <code>SELECT = 0;</code>
+     */
+    SELECT(0, 0),
+    /**
+     * <code>INSERT = 1;</code>
+     */
+    INSERT(1, 1),
+    /**
+     * <code>UPDATE = 2;</code>
+     */
+    UPDATE(2, 2),
+    /**
+     * <code>DELETE = 3;</code>
+     */
+    DELETE(3, 3),
+    /**
+     * <code>UPSERT = 4;</code>
+     */
+    UPSERT(4, 4),
+    /**
+     * <code>MERGE = 5;</code>
+     */
+    MERGE(5, 5),
+    /**
+     * <code>OTHER_DML = 6;</code>
+     */
+    OTHER_DML(6, 6),
+    /**
+     * <code>CREATE = 7;</code>
+     */
+    CREATE(7, 7),
+    /**
+     * <code>DROP = 8;</code>
+     */
+    DROP(8, 8),
+    /**
+     * <code>ALTER = 9;</code>
+     */
+    ALTER(9, 9),
+    /**
+     * <code>OTHER_DDL = 10;</code>
+     */
+    OTHER_DDL(10, 10),
+    /**
+     * <code>CALL = 11;</code>
+     */
+    CALL(11, 11),
+    UNRECOGNIZED(-1, -1),
+    ;
+
+    /**
+     * <code>SELECT = 0;</code>
+     */
+    public static final int SELECT_VALUE = 0;
+    /**
+     * <code>INSERT = 1;</code>
+     */
+    public static final int INSERT_VALUE = 1;
+    /**
+     * <code>UPDATE = 2;</code>
+     */
+    public static final int UPDATE_VALUE = 2;
+    /**
+     * <code>DELETE = 3;</code>
+     */
+    public static final int DELETE_VALUE = 3;
+    /**
+     * <code>UPSERT = 4;</code>
+     */
+    public static final int UPSERT_VALUE = 4;
+    /**
+     * <code>MERGE = 5;</code>
+     */
+    public static final int MERGE_VALUE = 5;
+    /**
+     * <code>OTHER_DML = 6;</code>
+     */
+    public static final int OTHER_DML_VALUE = 6;
+    /**
+     * <code>CREATE = 7;</code>
+     */
+    public static final int CREATE_VALUE = 7;
+    /**
+     * <code>DROP = 8;</code>
+     */
+    public static final int DROP_VALUE = 8;
+    /**
+     * <code>ALTER = 9;</code>
+     */
+    public static final int ALTER_VALUE = 9;
+    /**
+     * <code>OTHER_DDL = 10;</code>
+     */
+    public static final int OTHER_DDL_VALUE = 10;
+    /**
+     * <code>CALL = 11;</code>
+     */
+    public static final int CALL_VALUE = 11;
+
+
+    public final int getNumber() {
+      if (index == -1) {
+        throw new java.lang.IllegalArgumentException(
+            "Can't get the number of an unknown enum value.");
+      }
+      return value;
+    }
+
+    public static StatementType valueOf(int value) {
+      switch (value) {
+        case 0: return SELECT;
+        case 1: return INSERT;
+        case 2: return UPDATE;
+        case 3: return DELETE;
+        case 4: return UPSERT;
+        case 5: return MERGE;
+        case 6: return OTHER_DML;
+        case 7: return CREATE;
+        case 8: return DROP;
+        case 9: return ALTER;
+        case 10: return OTHER_DDL;
+        case 11: return CALL;
+        default: return null;
+      }
+    }
+
+    public static com.google.protobuf.Internal.EnumLiteMap<StatementType>
+        internalGetValueMap() {
+      return internalValueMap;
+    }
+    private static com.google.protobuf.Internal.EnumLiteMap<StatementType>
+        internalValueMap =
+          new com.google.protobuf.Internal.EnumLiteMap<StatementType>() {
+            public StatementType findValueByNumber(int number) {
+              return StatementType.valueOf(number);
+            }
+          };
+
+    public final com.google.protobuf.Descriptors.EnumValueDescriptor
+        getValueDescriptor() {
+      return getDescriptor().getValues().get(index);
+    }
+    public final com.google.protobuf.Descriptors.EnumDescriptor
+        getDescriptorForType() {
+      return getDescriptor();
+    }
+    public static final com.google.protobuf.Descriptors.EnumDescriptor
+        getDescriptor() {
+      return org.apache.calcite.avatica.proto.Common.getDescriptor().getEnumTypes().get(0);
+    }
+
+    private static final StatementType[] VALUES = values();
+
+    public static StatementType valueOf(
+        com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
+      if (desc.getType() != getDescriptor()) {
+        throw new java.lang.IllegalArgumentException(
+          "EnumValueDescriptor is not for this type.");
+      }
+      if (desc.getIndex() == -1) {
+        return UNRECOGNIZED;
+      }
+      return VALUES[desc.getIndex()];
+    }
+
+    private final int index;
+    private final int value;
+
+    private StatementType(int index, int value) {
+      this.index = index;
+      this.value = value;
+    }
+
+    // @@protoc_insertion_point(enum_scope:StatementType)
+  }
+
+  /**
    * Protobuf enum {@code Rep}
    */
   public enum Rep
@@ -313,7 +499,7 @@ package org.apache.calcite.avatica.proto;
     }
     public static final com.google.protobuf.Descriptors.EnumDescriptor
         getDescriptor() {
-      return org.apache.calcite.avatica.proto.Common.getDescriptor().getEnumTypes().get(0);
+      return org.apache.calcite.avatica.proto.Common.getDescriptor().getEnumTypes().get(1);
     }
 
     private static final Rep[] VALUES = values();
@@ -2078,6 +2264,15 @@ package org.apache.calcite.avatica.proto;
      * <code>optional .CursorFactory cursor_factory = 4;</code>
      */
     org.apache.calcite.avatica.proto.Common.CursorFactoryOrBuilder getCursorFactoryOrBuilder();
+
+    /**
+     * <code>optional .StatementType statementType = 5;</code>
+     */
+    int getStatementTypeValue();
+    /**
+     * <code>optional .StatementType statementType = 5;</code>
+     */
+    org.apache.calcite.avatica.proto.Common.StatementType getStatementType();
   }
   /**
    * Protobuf type {@code Signature}
@@ -2098,6 +2293,7 @@ package org.apache.calcite.avatica.proto;
       columns_ = java.util.Collections.emptyList();
       sql_ = "";
       parameters_ = java.util.Collections.emptyList();
+      statementType_ = 0;
     }
 
     @java.lang.Override
@@ -2158,6 +2354,12 @@ package org.apache.calcite.avatica.proto;
                 cursorFactory_ = subBuilder.buildPartial();
               }
 
+              break;
+            }
+            case 40: {
+              int rawValue = input.readEnum();
+
+              statementType_ = rawValue;
               break;
             }
           }
@@ -2332,6 +2534,22 @@ package org.apache.calcite.avatica.proto;
       return getCursorFactory();
     }
 
+    public static final int STATEMENTTYPE_FIELD_NUMBER = 5;
+    private int statementType_;
+    /**
+     * <code>optional .StatementType statementType = 5;</code>
+     */
+    public int getStatementTypeValue() {
+      return statementType_;
+    }
+    /**
+     * <code>optional .StatementType statementType = 5;</code>
+     */
+    public org.apache.calcite.avatica.proto.Common.StatementType getStatementType() {
+      org.apache.calcite.avatica.proto.Common.StatementType result = org.apache.calcite.avatica.proto.Common.StatementType.valueOf(statementType_);
+      return result == null ? org.apache.calcite.avatica.proto.Common.StatementType.UNRECOGNIZED : result;
+    }
+
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
@@ -2357,6 +2575,9 @@ package org.apache.calcite.avatica.proto;
       if (cursorFactory_ != null) {
         output.writeMessage(4, getCursorFactory());
       }
+      if (statementType_ != org.apache.calcite.avatica.proto.Common.StatementType.SELECT.getNumber()) {
+        output.writeEnum(5, statementType_);
+      }
     }
 
     private int memoizedSerializedSize = -1;
@@ -2380,6 +2601,10 @@ package org.apache.calcite.avatica.proto;
       if (cursorFactory_ != null) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(4, getCursorFactory());
+      }
+      if (statementType_ != org.apache.calcite.avatica.proto.Common.StatementType.SELECT.getNumber()) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(5, statementType_);
       }
       memoizedSerializedSize = size;
       return size;
@@ -2513,6 +2738,8 @@ package org.apache.calcite.avatica.proto;
           cursorFactory_ = null;
           cursorFactoryBuilder_ = null;
         }
+        statementType_ = 0;
+
         return this;
       }
 
@@ -2561,6 +2788,7 @@ package org.apache.calcite.avatica.proto;
         } else {
           result.cursorFactory_ = cursorFactoryBuilder_.build();
         }
+        result.statementType_ = statementType_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -2635,6 +2863,9 @@ package org.apache.calcite.avatica.proto;
         }
         if (other.hasCursorFactory()) {
           mergeCursorFactory(other.getCursorFactory());
+        }
+        if (other.statementType_ != 0) {
+          setStatementTypeValue(other.getStatementTypeValue());
         }
         onChanged();
         return this;
@@ -3328,6 +3559,50 @@ package org.apache.calcite.avatica.proto;
           cursorFactory_ = null;
         }
         return cursorFactoryBuilder_;
+      }
+
+      private int statementType_ = 0;
+      /**
+       * <code>optional .StatementType statementType = 5;</code>
+       */
+      public int getStatementTypeValue() {
+        return statementType_;
+      }
+      /**
+       * <code>optional .StatementType statementType = 5;</code>
+       */
+      public Builder setStatementTypeValue(int value) {
+        statementType_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional .StatementType statementType = 5;</code>
+       */
+      public org.apache.calcite.avatica.proto.Common.StatementType getStatementType() {
+        org.apache.calcite.avatica.proto.Common.StatementType result = org.apache.calcite.avatica.proto.Common.StatementType.valueOf(statementType_);
+        return result == null ? org.apache.calcite.avatica.proto.Common.StatementType.UNRECOGNIZED : result;
+      }
+      /**
+       * <code>optional .StatementType statementType = 5;</code>
+       */
+      public Builder setStatementType(org.apache.calcite.avatica.proto.Common.StatementType value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        
+        statementType_ = value.getNumber();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional .StatementType statementType = 5;</code>
+       */
+      public Builder clearStatementType() {
+        
+        statementType_ = 0;
+        onChanged();
+        return this;
       }
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
@@ -12224,54 +12499,59 @@ package org.apache.calcite.avatica.proto;
       "_isolation\030\004 \001(\r\022\017\n\007catalog\030\005 \001(\t\022\016\n\006sch" +
       "ema\030\006 \001(\t\"S\n\017StatementHandle\022\025\n\rconnecti" +
       "on_id\030\001 \001(\t\022\n\n\002id\030\002 \001(\r\022\035\n\tsignature\030\003 \001" +
-      "(\0132\n.Signature\"\211\001\n\tSignature\022 \n\007columns\030" +
+      "(\0132\n.Signature\"\260\001\n\tSignature\022 \n\007columns\030" +
       "\001 \003(\0132\017.ColumnMetaData\022\013\n\003sql\030\002 \001(\t\022%\n\np" +
       "arameters\030\003 \003(\0132\021.AvaticaParameter\022&\n\016cu",
-      "rsor_factory\030\004 \001(\0132\016.CursorFactory\"\255\003\n\016C" +
-      "olumnMetaData\022\017\n\007ordinal\030\001 \001(\r\022\026\n\016auto_i" +
-      "ncrement\030\002 \001(\010\022\026\n\016case_sensitive\030\003 \001(\010\022\022" +
-      "\n\nsearchable\030\004 \001(\010\022\020\n\010currency\030\005 \001(\010\022\020\n\010" +
-      "nullable\030\006 \001(\r\022\016\n\006signed\030\007 \001(\010\022\024\n\014displa" +
-      "y_size\030\010 \001(\r\022\r\n\005label\030\t \001(\t\022\023\n\013column_na" +
-      "me\030\n \001(\t\022\023\n\013schema_name\030\013 \001(\t\022\021\n\tprecisi" +
-      "on\030\014 \001(\r\022\r\n\005scale\030\r \001(\r\022\022\n\ntable_name\030\016 " +
-      "\001(\t\022\024\n\014catalog_name\030\017 \001(\t\022\021\n\tread_only\030\020" +
-      " \001(\010\022\020\n\010writable\030\021 \001(\010\022\033\n\023definitely_wri",
-      "table\030\022 \001(\010\022\031\n\021column_class_name\030\023 \001(\t\022\032" +
-      "\n\004type\030\024 \001(\0132\014.AvaticaType\"}\n\013AvaticaTyp" +
-      "e\022\n\n\002id\030\001 \001(\r\022\014\n\004name\030\002 \001(\t\022\021\n\003rep\030\003 \001(\016" +
-      "2\004.Rep\022 \n\007columns\030\004 \003(\0132\017.ColumnMetaData" +
-      "\022\037\n\tcomponent\030\005 \001(\0132\014.AvaticaType\"\221\001\n\020Av" +
-      "aticaParameter\022\016\n\006signed\030\001 \001(\010\022\021\n\tprecis" +
-      "ion\030\002 \001(\r\022\r\n\005scale\030\003 \001(\r\022\026\n\016parameter_ty" +
-      "pe\030\004 \001(\r\022\021\n\ttype_name\030\005 \001(\t\022\022\n\nclass_nam" +
-      "e\030\006 \001(\t\022\014\n\004name\030\007 \001(\t\"\263\001\n\rCursorFactory\022" +
-      "#\n\005style\030\001 \001(\0162\024.CursorFactory.Style\022\022\n\n",
-      "class_name\030\002 \001(\t\022\023\n\013field_names\030\003 \003(\t\"T\n" +
-      "\005Style\022\n\n\006OBJECT\020\000\022\n\n\006RECORD\020\001\022\025\n\021RECORD" +
-      "_PROJECTION\020\002\022\t\n\005ARRAY\020\003\022\010\n\004LIST\020\004\022\007\n\003MA" +
-      "P\020\005\"9\n\005Frame\022\016\n\006offset\030\001 \001(\004\022\014\n\004done\030\002 \001" +
-      "(\010\022\022\n\004rows\030\003 \003(\0132\004.Row\"!\n\003Row\022\032\n\005value\030\001" +
-      " \003(\0132\013.TypedValue\"3\n\020DatabaseProperty\022\014\n" +
-      "\004name\030\001 \001(\t\022\021\n\tfunctions\030\002 \003(\t\"4\n\013WireMe" +
-      "ssage\022\014\n\004name\030\001 \001(\t\022\027\n\017wrapped_message\030\002" +
-      " \001(\014\"\232\001\n\nTypedValue\022\022\n\004type\030\001 \001(\0162\004.Rep\022" +
-      "\022\n\nbool_value\030\002 \001(\010\022\024\n\014string_value\030\003 \001(",
-      "\t\022\024\n\014number_value\030\004 \001(\022\022\024\n\014bytes_values\030" +
-      "\005 \001(\014\022\024\n\014double_value\030\006 \001(\001\022\014\n\004null\030\007 \001(" +
-      "\010*\275\003\n\003Rep\022\025\n\021PRIMITIVE_BOOLEAN\020\000\022\022\n\016PRIM" +
-      "ITIVE_BYTE\020\001\022\022\n\016PRIMITIVE_CHAR\020\002\022\023\n\017PRIM" +
-      "ITIVE_SHORT\020\003\022\021\n\rPRIMITIVE_INT\020\004\022\022\n\016PRIM" +
-      "ITIVE_LONG\020\005\022\023\n\017PRIMITIVE_FLOAT\020\006\022\024\n\020PRI" +
-      "MITIVE_DOUBLE\020\007\022\013\n\007BOOLEAN\020\010\022\010\n\004BYTE\020\t\022\r" +
-      "\n\tCHARACTER\020\n\022\t\n\005SHORT\020\013\022\013\n\007INTEGER\020\014\022\010\n" +
-      "\004LONG\020\r\022\t\n\005FLOAT\020\016\022\n\n\006DOUBLE\020\017\022\017\n\013BIG_IN" +
-      "TEGER\020\031\022\017\n\013BIG_DECIMAL\020\032\022\021\n\rJAVA_SQL_TIM",
-      "E\020\020\022\026\n\022JAVA_SQL_TIMESTAMP\020\021\022\021\n\rJAVA_SQL_" +
-      "DATE\020\022\022\022\n\016JAVA_UTIL_DATE\020\023\022\017\n\013BYTE_STRIN" +
-      "G\020\024\022\n\n\006STRING\020\025\022\n\n\006NUMBER\020\026\022\n\n\006OBJECT\020\027\022" +
-      "\010\n\004NULL\020\030B\"\n org.apache.calcite.avatica." +
-      "protob\006proto3"
+      "rsor_factory\030\004 \001(\0132\016.CursorFactory\022%\n\rst" +
+      "atementType\030\005 \001(\0162\016.StatementType\"\255\003\n\016Co" +
+      "lumnMetaData\022\017\n\007ordinal\030\001 \001(\r\022\026\n\016auto_in" +
+      "crement\030\002 \001(\010\022\026\n\016case_sensitive\030\003 \001(\010\022\022\n" +
+      "\nsearchable\030\004 \001(\010\022\020\n\010currency\030\005 \001(\010\022\020\n\010n" +
+      "ullable\030\006 \001(\r\022\016\n\006signed\030\007 \001(\010\022\024\n\014display" +
+      "_size\030\010 \001(\r\022\r\n\005label\030\t \001(\t\022\023\n\013column_nam" +
+      "e\030\n \001(\t\022\023\n\013schema_name\030\013 \001(\t\022\021\n\tprecisio" +
+      "n\030\014 \001(\r\022\r\n\005scale\030\r \001(\r\022\022\n\ntable_name\030\016 \001" +
+      "(\t\022\024\n\014catalog_name\030\017 \001(\t\022\021\n\tread_only\030\020 ",
+      "\001(\010\022\020\n\010writable\030\021 \001(\010\022\033\n\023definitely_writ" +
+      "able\030\022 \001(\010\022\031\n\021column_class_name\030\023 \001(\t\022\032\n" +
+      "\004type\030\024 \001(\0132\014.AvaticaType\"}\n\013AvaticaType" +
+      "\022\n\n\002id\030\001 \001(\r\022\014\n\004name\030\002 \001(\t\022\021\n\003rep\030\003 \001(\0162" +
+      "\004.Rep\022 \n\007columns\030\004 \003(\0132\017.ColumnMetaData\022" +
+      "\037\n\tcomponent\030\005 \001(\0132\014.AvaticaType\"\221\001\n\020Ava" +
+      "ticaParameter\022\016\n\006signed\030\001 \001(\010\022\021\n\tprecisi" +
+      "on\030\002 \001(\r\022\r\n\005scale\030\003 \001(\r\022\026\n\016parameter_typ" +
+      "e\030\004 \001(\r\022\021\n\ttype_name\030\005 \001(\t\022\022\n\nclass_name" +
+      "\030\006 \001(\t\022\014\n\004name\030\007 \001(\t\"\263\001\n\rCursorFactory\022#",
+      "\n\005style\030\001 \001(\0162\024.CursorFactory.Style\022\022\n\nc" +
+      "lass_name\030\002 \001(\t\022\023\n\013field_names\030\003 \003(\t\"T\n\005" +
+      "Style\022\n\n\006OBJECT\020\000\022\n\n\006RECORD\020\001\022\025\n\021RECORD_" +
+      "PROJECTION\020\002\022\t\n\005ARRAY\020\003\022\010\n\004LIST\020\004\022\007\n\003MAP" +
+      "\020\005\"9\n\005Frame\022\016\n\006offset\030\001 \001(\004\022\014\n\004done\030\002 \001(" +
+      "\010\022\022\n\004rows\030\003 \003(\0132\004.Row\"!\n\003Row\022\032\n\005value\030\001 " +
+      "\003(\0132\013.TypedValue\"3\n\020DatabaseProperty\022\014\n\004" +
+      "name\030\001 \001(\t\022\021\n\tfunctions\030\002 \003(\t\"4\n\013WireMes" +
+      "sage\022\014\n\004name\030\001 \001(\t\022\027\n\017wrapped_message\030\002 " +
+      "\001(\014\"\232\001\n\nTypedValue\022\022\n\004type\030\001 \001(\0162\004.Rep\022\022",
+      "\n\nbool_value\030\002 \001(\010\022\024\n\014string_value\030\003 \001(\t" +
+      "\022\024\n\014number_value\030\004 \001(\022\022\024\n\014bytes_values\030\005" +
+      " \001(\014\022\024\n\014double_value\030\006 \001(\001\022\014\n\004null\030\007 \001(\010" +
+      "*\237\001\n\rStatementType\022\n\n\006SELECT\020\000\022\n\n\006INSERT" +
+      "\020\001\022\n\n\006UPDATE\020\002\022\n\n\006DELETE\020\003\022\n\n\006UPSERT\020\004\022\t" +
+      "\n\005MERGE\020\005\022\r\n\tOTHER_DML\020\006\022\n\n\006CREATE\020\007\022\010\n\004" +
+      "DROP\020\010\022\t\n\005ALTER\020\t\022\r\n\tOTHER_DDL\020\n\022\010\n\004CALL" +
+      "\020\013*\275\003\n\003Rep\022\025\n\021PRIMITIVE_BOOLEAN\020\000\022\022\n\016PRI" +
+      "MITIVE_BYTE\020\001\022\022\n\016PRIMITIVE_CHAR\020\002\022\023\n\017PRI" +
+      "MITIVE_SHORT\020\003\022\021\n\rPRIMITIVE_INT\020\004\022\022\n\016PRI",
+      "MITIVE_LONG\020\005\022\023\n\017PRIMITIVE_FLOAT\020\006\022\024\n\020PR" +
+      "IMITIVE_DOUBLE\020\007\022\013\n\007BOOLEAN\020\010\022\010\n\004BYTE\020\t\022" +
+      "\r\n\tCHARACTER\020\n\022\t\n\005SHORT\020\013\022\013\n\007INTEGER\020\014\022\010" +
+      "\n\004LONG\020\r\022\t\n\005FLOAT\020\016\022\n\n\006DOUBLE\020\017\022\017\n\013BIG_I" +
+      "NTEGER\020\031\022\017\n\013BIG_DECIMAL\020\032\022\021\n\rJAVA_SQL_TI" +
+      "ME\020\020\022\026\n\022JAVA_SQL_TIMESTAMP\020\021\022\021\n\rJAVA_SQL" +
+      "_DATE\020\022\022\022\n\016JAVA_UTIL_DATE\020\023\022\017\n\013BYTE_STRI" +
+      "NG\020\024\022\n\n\006STRING\020\025\022\n\n\006NUMBER\020\026\022\n\n\006OBJECT\020\027" +
+      "\022\010\n\004NULL\020\030B\"\n org.apache.calcite.avatica" +
+      ".protob\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -12302,7 +12582,7 @@ package org.apache.calcite.avatica.proto;
     internal_static_Signature_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_Signature_descriptor,
-        new java.lang.String[] { "Columns", "Sql", "Parameters", "CursorFactory", });
+        new java.lang.String[] { "Columns", "Sql", "Parameters", "CursorFactory", "StatementType", });
     internal_static_ColumnMetaData_descriptor =
       getDescriptor().getMessageTypes().get(3);
     internal_static_ColumnMetaData_fieldAccessorTable = new

--- a/avatica/src/main/java/org/apache/calcite/avatica/proto/Requests.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/proto/Requests.java
@@ -5044,59 +5044,6 @@ package org.apache.calcite.avatica.proto;
      * </pre>
      */
     int getFetchMaxRowCount();
-
-    /**
-     * <code>repeated .TypedValue parameter_values = 5;</code>
-     *
-     * <pre>
-     * List of parameter values if statement is to be executed. Else, none.
-     * </pre>
-     */
-    java.util.List<org.apache.calcite.avatica.proto.Common.TypedValue> 
-        getParameterValuesList();
-    /**
-     * <code>repeated .TypedValue parameter_values = 5;</code>
-     *
-     * <pre>
-     * List of parameter values if statement is to be executed. Else, none.
-     * </pre>
-     */
-    org.apache.calcite.avatica.proto.Common.TypedValue getParameterValues(int index);
-    /**
-     * <code>repeated .TypedValue parameter_values = 5;</code>
-     *
-     * <pre>
-     * List of parameter values if statement is to be executed. Else, none.
-     * </pre>
-     */
-    int getParameterValuesCount();
-    /**
-     * <code>repeated .TypedValue parameter_values = 5;</code>
-     *
-     * <pre>
-     * List of parameter values if statement is to be executed. Else, none.
-     * </pre>
-     */
-    java.util.List<? extends org.apache.calcite.avatica.proto.Common.TypedValueOrBuilder> 
-        getParameterValuesOrBuilderList();
-    /**
-     * <code>repeated .TypedValue parameter_values = 5;</code>
-     *
-     * <pre>
-     * List of parameter values if statement is to be executed. Else, none.
-     * </pre>
-     */
-    org.apache.calcite.avatica.proto.Common.TypedValueOrBuilder getParameterValuesOrBuilder(
-        int index);
-
-    /**
-     * <code>optional bool has_parameter_values = 6;</code>
-     *
-     * <pre>
-     * Having an empty list of param values is distinct from a null param list
-     * </pre>
-     */
-    boolean getHasParameterValues();
   }
   /**
    * Protobuf type {@code FetchRequest}
@@ -5118,8 +5065,6 @@ package org.apache.calcite.avatica.proto;
       statementId_ = 0;
       offset_ = 0L;
       fetchMaxRowCount_ = 0;
-      parameterValues_ = java.util.Collections.emptyList();
-      hasParameterValues_ = false;
     }
 
     @java.lang.Override
@@ -5168,19 +5113,6 @@ package org.apache.calcite.avatica.proto;
               fetchMaxRowCount_ = input.readUInt32();
               break;
             }
-            case 42: {
-              if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
-                parameterValues_ = new java.util.ArrayList<org.apache.calcite.avatica.proto.Common.TypedValue>();
-                mutable_bitField0_ |= 0x00000010;
-              }
-              parameterValues_.add(input.readMessage(org.apache.calcite.avatica.proto.Common.TypedValue.PARSER, extensionRegistry));
-              break;
-            }
-            case 48: {
-
-              hasParameterValues_ = input.readBool();
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -5189,9 +5121,6 @@ package org.apache.calcite.avatica.proto;
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e.getMessage()).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
-          parameterValues_ = java.util.Collections.unmodifiableList(parameterValues_);
-        }
         makeExtensionsImmutable();
       }
     }
@@ -5222,7 +5151,6 @@ package org.apache.calcite.avatica.proto;
       return PARSER;
     }
 
-    private int bitField0_;
     public static final int CONNECTION_ID_FIELD_NUMBER = 1;
     private java.lang.Object connectionId_;
     /**
@@ -5290,74 +5218,6 @@ package org.apache.calcite.avatica.proto;
       return fetchMaxRowCount_;
     }
 
-    public static final int PARAMETER_VALUES_FIELD_NUMBER = 5;
-    private java.util.List<org.apache.calcite.avatica.proto.Common.TypedValue> parameterValues_;
-    /**
-     * <code>repeated .TypedValue parameter_values = 5;</code>
-     *
-     * <pre>
-     * List of parameter values if statement is to be executed. Else, none.
-     * </pre>
-     */
-    public java.util.List<org.apache.calcite.avatica.proto.Common.TypedValue> getParameterValuesList() {
-      return parameterValues_;
-    }
-    /**
-     * <code>repeated .TypedValue parameter_values = 5;</code>
-     *
-     * <pre>
-     * List of parameter values if statement is to be executed. Else, none.
-     * </pre>
-     */
-    public java.util.List<? extends org.apache.calcite.avatica.proto.Common.TypedValueOrBuilder> 
-        getParameterValuesOrBuilderList() {
-      return parameterValues_;
-    }
-    /**
-     * <code>repeated .TypedValue parameter_values = 5;</code>
-     *
-     * <pre>
-     * List of parameter values if statement is to be executed. Else, none.
-     * </pre>
-     */
-    public int getParameterValuesCount() {
-      return parameterValues_.size();
-    }
-    /**
-     * <code>repeated .TypedValue parameter_values = 5;</code>
-     *
-     * <pre>
-     * List of parameter values if statement is to be executed. Else, none.
-     * </pre>
-     */
-    public org.apache.calcite.avatica.proto.Common.TypedValue getParameterValues(int index) {
-      return parameterValues_.get(index);
-    }
-    /**
-     * <code>repeated .TypedValue parameter_values = 5;</code>
-     *
-     * <pre>
-     * List of parameter values if statement is to be executed. Else, none.
-     * </pre>
-     */
-    public org.apache.calcite.avatica.proto.Common.TypedValueOrBuilder getParameterValuesOrBuilder(
-        int index) {
-      return parameterValues_.get(index);
-    }
-
-    public static final int HAS_PARAMETER_VALUES_FIELD_NUMBER = 6;
-    private boolean hasParameterValues_;
-    /**
-     * <code>optional bool has_parameter_values = 6;</code>
-     *
-     * <pre>
-     * Having an empty list of param values is distinct from a null param list
-     * </pre>
-     */
-    public boolean getHasParameterValues() {
-      return hasParameterValues_;
-    }
-
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
@@ -5383,12 +5243,6 @@ package org.apache.calcite.avatica.proto;
       if (fetchMaxRowCount_ != 0) {
         output.writeUInt32(4, fetchMaxRowCount_);
       }
-      for (int i = 0; i < parameterValues_.size(); i++) {
-        output.writeMessage(5, parameterValues_.get(i));
-      }
-      if (hasParameterValues_ != false) {
-        output.writeBool(6, hasParameterValues_);
-      }
     }
 
     private int memoizedSerializedSize = -1;
@@ -5412,14 +5266,6 @@ package org.apache.calcite.avatica.proto;
       if (fetchMaxRowCount_ != 0) {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt32Size(4, fetchMaxRowCount_);
-      }
-      for (int i = 0; i < parameterValues_.size(); i++) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(5, parameterValues_.get(i));
-      }
-      if (hasParameterValues_ != false) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeBoolSize(6, hasParameterValues_);
       }
       memoizedSerializedSize = size;
       return size;
@@ -5527,7 +5373,6 @@ package org.apache.calcite.avatica.proto;
       }
       private void maybeForceBuilderInitialization() {
         if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-          getParameterValuesFieldBuilder();
         }
       }
       public Builder clear() {
@@ -5539,14 +5384,6 @@ package org.apache.calcite.avatica.proto;
         offset_ = 0L;
 
         fetchMaxRowCount_ = 0;
-
-        if (parameterValuesBuilder_ == null) {
-          parameterValues_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000010);
-        } else {
-          parameterValuesBuilder_.clear();
-        }
-        hasParameterValues_ = false;
 
         return this;
       }
@@ -5570,23 +5407,10 @@ package org.apache.calcite.avatica.proto;
 
       public org.apache.calcite.avatica.proto.Requests.FetchRequest buildPartial() {
         org.apache.calcite.avatica.proto.Requests.FetchRequest result = new org.apache.calcite.avatica.proto.Requests.FetchRequest(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
         result.connectionId_ = connectionId_;
         result.statementId_ = statementId_;
         result.offset_ = offset_;
         result.fetchMaxRowCount_ = fetchMaxRowCount_;
-        if (parameterValuesBuilder_ == null) {
-          if (((bitField0_ & 0x00000010) == 0x00000010)) {
-            parameterValues_ = java.util.Collections.unmodifiableList(parameterValues_);
-            bitField0_ = (bitField0_ & ~0x00000010);
-          }
-          result.parameterValues_ = parameterValues_;
-        } else {
-          result.parameterValues_ = parameterValuesBuilder_.build();
-        }
-        result.hasParameterValues_ = hasParameterValues_;
-        result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
       }
@@ -5615,35 +5439,6 @@ package org.apache.calcite.avatica.proto;
         if (other.getFetchMaxRowCount() != 0) {
           setFetchMaxRowCount(other.getFetchMaxRowCount());
         }
-        if (parameterValuesBuilder_ == null) {
-          if (!other.parameterValues_.isEmpty()) {
-            if (parameterValues_.isEmpty()) {
-              parameterValues_ = other.parameterValues_;
-              bitField0_ = (bitField0_ & ~0x00000010);
-            } else {
-              ensureParameterValuesIsMutable();
-              parameterValues_.addAll(other.parameterValues_);
-            }
-            onChanged();
-          }
-        } else {
-          if (!other.parameterValues_.isEmpty()) {
-            if (parameterValuesBuilder_.isEmpty()) {
-              parameterValuesBuilder_.dispose();
-              parameterValuesBuilder_ = null;
-              parameterValues_ = other.parameterValues_;
-              bitField0_ = (bitField0_ & ~0x00000010);
-              parameterValuesBuilder_ = 
-                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
-                   getParameterValuesFieldBuilder() : null;
-            } else {
-              parameterValuesBuilder_.addAllMessages(other.parameterValues_);
-            }
-          }
-        }
-        if (other.getHasParameterValues() != false) {
-          setHasParameterValues(other.getHasParameterValues());
-        }
         onChanged();
         return this;
       }
@@ -5669,7 +5464,6 @@ package org.apache.calcite.avatica.proto;
         }
         return this;
       }
-      private int bitField0_;
 
       private java.lang.Object connectionId_ = "";
       /**
@@ -5827,356 +5621,6 @@ package org.apache.calcite.avatica.proto;
       public Builder clearFetchMaxRowCount() {
         
         fetchMaxRowCount_ = 0;
-        onChanged();
-        return this;
-      }
-
-      private java.util.List<org.apache.calcite.avatica.proto.Common.TypedValue> parameterValues_ =
-        java.util.Collections.emptyList();
-      private void ensureParameterValuesIsMutable() {
-        if (!((bitField0_ & 0x00000010) == 0x00000010)) {
-          parameterValues_ = new java.util.ArrayList<org.apache.calcite.avatica.proto.Common.TypedValue>(parameterValues_);
-          bitField0_ |= 0x00000010;
-         }
-      }
-
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.apache.calcite.avatica.proto.Common.TypedValue, org.apache.calcite.avatica.proto.Common.TypedValue.Builder, org.apache.calcite.avatica.proto.Common.TypedValueOrBuilder> parameterValuesBuilder_;
-
-      /**
-       * <code>repeated .TypedValue parameter_values = 5;</code>
-       *
-       * <pre>
-       * List of parameter values if statement is to be executed. Else, none.
-       * </pre>
-       */
-      public java.util.List<org.apache.calcite.avatica.proto.Common.TypedValue> getParameterValuesList() {
-        if (parameterValuesBuilder_ == null) {
-          return java.util.Collections.unmodifiableList(parameterValues_);
-        } else {
-          return parameterValuesBuilder_.getMessageList();
-        }
-      }
-      /**
-       * <code>repeated .TypedValue parameter_values = 5;</code>
-       *
-       * <pre>
-       * List of parameter values if statement is to be executed. Else, none.
-       * </pre>
-       */
-      public int getParameterValuesCount() {
-        if (parameterValuesBuilder_ == null) {
-          return parameterValues_.size();
-        } else {
-          return parameterValuesBuilder_.getCount();
-        }
-      }
-      /**
-       * <code>repeated .TypedValue parameter_values = 5;</code>
-       *
-       * <pre>
-       * List of parameter values if statement is to be executed. Else, none.
-       * </pre>
-       */
-      public org.apache.calcite.avatica.proto.Common.TypedValue getParameterValues(int index) {
-        if (parameterValuesBuilder_ == null) {
-          return parameterValues_.get(index);
-        } else {
-          return parameterValuesBuilder_.getMessage(index);
-        }
-      }
-      /**
-       * <code>repeated .TypedValue parameter_values = 5;</code>
-       *
-       * <pre>
-       * List of parameter values if statement is to be executed. Else, none.
-       * </pre>
-       */
-      public Builder setParameterValues(
-          int index, org.apache.calcite.avatica.proto.Common.TypedValue value) {
-        if (parameterValuesBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureParameterValuesIsMutable();
-          parameterValues_.set(index, value);
-          onChanged();
-        } else {
-          parameterValuesBuilder_.setMessage(index, value);
-        }
-        return this;
-      }
-      /**
-       * <code>repeated .TypedValue parameter_values = 5;</code>
-       *
-       * <pre>
-       * List of parameter values if statement is to be executed. Else, none.
-       * </pre>
-       */
-      public Builder setParameterValues(
-          int index, org.apache.calcite.avatica.proto.Common.TypedValue.Builder builderForValue) {
-        if (parameterValuesBuilder_ == null) {
-          ensureParameterValuesIsMutable();
-          parameterValues_.set(index, builderForValue.build());
-          onChanged();
-        } else {
-          parameterValuesBuilder_.setMessage(index, builderForValue.build());
-        }
-        return this;
-      }
-      /**
-       * <code>repeated .TypedValue parameter_values = 5;</code>
-       *
-       * <pre>
-       * List of parameter values if statement is to be executed. Else, none.
-       * </pre>
-       */
-      public Builder addParameterValues(org.apache.calcite.avatica.proto.Common.TypedValue value) {
-        if (parameterValuesBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureParameterValuesIsMutable();
-          parameterValues_.add(value);
-          onChanged();
-        } else {
-          parameterValuesBuilder_.addMessage(value);
-        }
-        return this;
-      }
-      /**
-       * <code>repeated .TypedValue parameter_values = 5;</code>
-       *
-       * <pre>
-       * List of parameter values if statement is to be executed. Else, none.
-       * </pre>
-       */
-      public Builder addParameterValues(
-          int index, org.apache.calcite.avatica.proto.Common.TypedValue value) {
-        if (parameterValuesBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureParameterValuesIsMutable();
-          parameterValues_.add(index, value);
-          onChanged();
-        } else {
-          parameterValuesBuilder_.addMessage(index, value);
-        }
-        return this;
-      }
-      /**
-       * <code>repeated .TypedValue parameter_values = 5;</code>
-       *
-       * <pre>
-       * List of parameter values if statement is to be executed. Else, none.
-       * </pre>
-       */
-      public Builder addParameterValues(
-          org.apache.calcite.avatica.proto.Common.TypedValue.Builder builderForValue) {
-        if (parameterValuesBuilder_ == null) {
-          ensureParameterValuesIsMutable();
-          parameterValues_.add(builderForValue.build());
-          onChanged();
-        } else {
-          parameterValuesBuilder_.addMessage(builderForValue.build());
-        }
-        return this;
-      }
-      /**
-       * <code>repeated .TypedValue parameter_values = 5;</code>
-       *
-       * <pre>
-       * List of parameter values if statement is to be executed. Else, none.
-       * </pre>
-       */
-      public Builder addParameterValues(
-          int index, org.apache.calcite.avatica.proto.Common.TypedValue.Builder builderForValue) {
-        if (parameterValuesBuilder_ == null) {
-          ensureParameterValuesIsMutable();
-          parameterValues_.add(index, builderForValue.build());
-          onChanged();
-        } else {
-          parameterValuesBuilder_.addMessage(index, builderForValue.build());
-        }
-        return this;
-      }
-      /**
-       * <code>repeated .TypedValue parameter_values = 5;</code>
-       *
-       * <pre>
-       * List of parameter values if statement is to be executed. Else, none.
-       * </pre>
-       */
-      public Builder addAllParameterValues(
-          java.lang.Iterable<? extends org.apache.calcite.avatica.proto.Common.TypedValue> values) {
-        if (parameterValuesBuilder_ == null) {
-          ensureParameterValuesIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, parameterValues_);
-          onChanged();
-        } else {
-          parameterValuesBuilder_.addAllMessages(values);
-        }
-        return this;
-      }
-      /**
-       * <code>repeated .TypedValue parameter_values = 5;</code>
-       *
-       * <pre>
-       * List of parameter values if statement is to be executed. Else, none.
-       * </pre>
-       */
-      public Builder clearParameterValues() {
-        if (parameterValuesBuilder_ == null) {
-          parameterValues_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000010);
-          onChanged();
-        } else {
-          parameterValuesBuilder_.clear();
-        }
-        return this;
-      }
-      /**
-       * <code>repeated .TypedValue parameter_values = 5;</code>
-       *
-       * <pre>
-       * List of parameter values if statement is to be executed. Else, none.
-       * </pre>
-       */
-      public Builder removeParameterValues(int index) {
-        if (parameterValuesBuilder_ == null) {
-          ensureParameterValuesIsMutable();
-          parameterValues_.remove(index);
-          onChanged();
-        } else {
-          parameterValuesBuilder_.remove(index);
-        }
-        return this;
-      }
-      /**
-       * <code>repeated .TypedValue parameter_values = 5;</code>
-       *
-       * <pre>
-       * List of parameter values if statement is to be executed. Else, none.
-       * </pre>
-       */
-      public org.apache.calcite.avatica.proto.Common.TypedValue.Builder getParameterValuesBuilder(
-          int index) {
-        return getParameterValuesFieldBuilder().getBuilder(index);
-      }
-      /**
-       * <code>repeated .TypedValue parameter_values = 5;</code>
-       *
-       * <pre>
-       * List of parameter values if statement is to be executed. Else, none.
-       * </pre>
-       */
-      public org.apache.calcite.avatica.proto.Common.TypedValueOrBuilder getParameterValuesOrBuilder(
-          int index) {
-        if (parameterValuesBuilder_ == null) {
-          return parameterValues_.get(index);  } else {
-          return parameterValuesBuilder_.getMessageOrBuilder(index);
-        }
-      }
-      /**
-       * <code>repeated .TypedValue parameter_values = 5;</code>
-       *
-       * <pre>
-       * List of parameter values if statement is to be executed. Else, none.
-       * </pre>
-       */
-      public java.util.List<? extends org.apache.calcite.avatica.proto.Common.TypedValueOrBuilder> 
-           getParameterValuesOrBuilderList() {
-        if (parameterValuesBuilder_ != null) {
-          return parameterValuesBuilder_.getMessageOrBuilderList();
-        } else {
-          return java.util.Collections.unmodifiableList(parameterValues_);
-        }
-      }
-      /**
-       * <code>repeated .TypedValue parameter_values = 5;</code>
-       *
-       * <pre>
-       * List of parameter values if statement is to be executed. Else, none.
-       * </pre>
-       */
-      public org.apache.calcite.avatica.proto.Common.TypedValue.Builder addParameterValuesBuilder() {
-        return getParameterValuesFieldBuilder().addBuilder(
-            org.apache.calcite.avatica.proto.Common.TypedValue.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .TypedValue parameter_values = 5;</code>
-       *
-       * <pre>
-       * List of parameter values if statement is to be executed. Else, none.
-       * </pre>
-       */
-      public org.apache.calcite.avatica.proto.Common.TypedValue.Builder addParameterValuesBuilder(
-          int index) {
-        return getParameterValuesFieldBuilder().addBuilder(
-            index, org.apache.calcite.avatica.proto.Common.TypedValue.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .TypedValue parameter_values = 5;</code>
-       *
-       * <pre>
-       * List of parameter values if statement is to be executed. Else, none.
-       * </pre>
-       */
-      public java.util.List<org.apache.calcite.avatica.proto.Common.TypedValue.Builder> 
-           getParameterValuesBuilderList() {
-        return getParameterValuesFieldBuilder().getBuilderList();
-      }
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.apache.calcite.avatica.proto.Common.TypedValue, org.apache.calcite.avatica.proto.Common.TypedValue.Builder, org.apache.calcite.avatica.proto.Common.TypedValueOrBuilder> 
-          getParameterValuesFieldBuilder() {
-        if (parameterValuesBuilder_ == null) {
-          parameterValuesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              org.apache.calcite.avatica.proto.Common.TypedValue, org.apache.calcite.avatica.proto.Common.TypedValue.Builder, org.apache.calcite.avatica.proto.Common.TypedValueOrBuilder>(
-                  parameterValues_,
-                  ((bitField0_ & 0x00000010) == 0x00000010),
-                  getParentForChildren(),
-                  isClean());
-          parameterValues_ = null;
-        }
-        return parameterValuesBuilder_;
-      }
-
-      private boolean hasParameterValues_ ;
-      /**
-       * <code>optional bool has_parameter_values = 6;</code>
-       *
-       * <pre>
-       * Having an empty list of param values is distinct from a null param list
-       * </pre>
-       */
-      public boolean getHasParameterValues() {
-        return hasParameterValues_;
-      }
-      /**
-       * <code>optional bool has_parameter_values = 6;</code>
-       *
-       * <pre>
-       * Having an empty list of param values is distinct from a null param list
-       * </pre>
-       */
-      public Builder setHasParameterValues(boolean value) {
-        
-        hasParameterValues_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>optional bool has_parameter_values = 6;</code>
-       *
-       * <pre>
-       * Having an empty list of param values is distinct from a null param list
-       * </pre>
-       */
-      public Builder clearHasParameterValues() {
-        
-        hasParameterValues_ = false;
         onChanged();
         return this;
       }
@@ -8221,6 +7665,981 @@ package org.apache.calcite.avatica.proto;
 
   }
 
+  public interface ExecuteRequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:ExecuteRequest)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional .StatementHandle statementHandle = 1;</code>
+     */
+    boolean hasStatementHandle();
+    /**
+     * <code>optional .StatementHandle statementHandle = 1;</code>
+     */
+    org.apache.calcite.avatica.proto.Common.StatementHandle getStatementHandle();
+    /**
+     * <code>optional .StatementHandle statementHandle = 1;</code>
+     */
+    org.apache.calcite.avatica.proto.Common.StatementHandleOrBuilder getStatementHandleOrBuilder();
+
+    /**
+     * <code>repeated .TypedValue parameter_values = 2;</code>
+     */
+    java.util.List<org.apache.calcite.avatica.proto.Common.TypedValue> 
+        getParameterValuesList();
+    /**
+     * <code>repeated .TypedValue parameter_values = 2;</code>
+     */
+    org.apache.calcite.avatica.proto.Common.TypedValue getParameterValues(int index);
+    /**
+     * <code>repeated .TypedValue parameter_values = 2;</code>
+     */
+    int getParameterValuesCount();
+    /**
+     * <code>repeated .TypedValue parameter_values = 2;</code>
+     */
+    java.util.List<? extends org.apache.calcite.avatica.proto.Common.TypedValueOrBuilder> 
+        getParameterValuesOrBuilderList();
+    /**
+     * <code>repeated .TypedValue parameter_values = 2;</code>
+     */
+    org.apache.calcite.avatica.proto.Common.TypedValueOrBuilder getParameterValuesOrBuilder(
+        int index);
+
+    /**
+     * <code>optional uint64 max_row_count = 3;</code>
+     */
+    long getMaxRowCount();
+
+    /**
+     * <code>optional bool has_parameter_values = 4;</code>
+     */
+    boolean getHasParameterValues();
+  }
+  /**
+   * Protobuf type {@code ExecuteRequest}
+   *
+   * <pre>
+   * Request for Meta#execute(Meta.ConnectionHandle, list, long)
+   * </pre>
+   */
+  public  static final class ExecuteRequest extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:ExecuteRequest)
+      ExecuteRequestOrBuilder {
+    // Use ExecuteRequest.newBuilder() to construct.
+    private ExecuteRequest(com.google.protobuf.GeneratedMessage.Builder builder) {
+      super(builder);
+    }
+    private ExecuteRequest() {
+      parameterValues_ = java.util.Collections.emptyList();
+      maxRowCount_ = 0L;
+      hasParameterValues_ = false;
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return com.google.protobuf.UnknownFieldSet.getDefaultInstance();
+    }
+    private ExecuteRequest(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      int mutable_bitField0_ = 0;
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!input.skipField(tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              org.apache.calcite.avatica.proto.Common.StatementHandle.Builder subBuilder = null;
+              if (statementHandle_ != null) {
+                subBuilder = statementHandle_.toBuilder();
+              }
+              statementHandle_ = input.readMessage(org.apache.calcite.avatica.proto.Common.StatementHandle.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(statementHandle_);
+                statementHandle_ = subBuilder.buildPartial();
+              }
+
+              break;
+            }
+            case 18: {
+              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+                parameterValues_ = new java.util.ArrayList<org.apache.calcite.avatica.proto.Common.TypedValue>();
+                mutable_bitField0_ |= 0x00000002;
+              }
+              parameterValues_.add(input.readMessage(org.apache.calcite.avatica.proto.Common.TypedValue.PARSER, extensionRegistry));
+              break;
+            }
+            case 24: {
+
+              maxRowCount_ = input.readUInt64();
+              break;
+            }
+            case 32: {
+
+              hasParameterValues_ = input.readBool();
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+          parameterValues_ = java.util.Collections.unmodifiableList(parameterValues_);
+        }
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.apache.calcite.avatica.proto.Requests.internal_static_ExecuteRequest_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.apache.calcite.avatica.proto.Requests.internal_static_ExecuteRequest_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.calcite.avatica.proto.Requests.ExecuteRequest.class, org.apache.calcite.avatica.proto.Requests.ExecuteRequest.Builder.class);
+    }
+
+    public static final com.google.protobuf.Parser<ExecuteRequest> PARSER =
+        new com.google.protobuf.AbstractParser<ExecuteRequest>() {
+      public ExecuteRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new ExecuteRequest(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<ExecuteRequest> getParserForType() {
+      return PARSER;
+    }
+
+    private int bitField0_;
+    public static final int STATEMENTHANDLE_FIELD_NUMBER = 1;
+    private org.apache.calcite.avatica.proto.Common.StatementHandle statementHandle_;
+    /**
+     * <code>optional .StatementHandle statementHandle = 1;</code>
+     */
+    public boolean hasStatementHandle() {
+      return statementHandle_ != null;
+    }
+    /**
+     * <code>optional .StatementHandle statementHandle = 1;</code>
+     */
+    public org.apache.calcite.avatica.proto.Common.StatementHandle getStatementHandle() {
+      return statementHandle_ == null ? org.apache.calcite.avatica.proto.Common.StatementHandle.getDefaultInstance() : statementHandle_;
+    }
+    /**
+     * <code>optional .StatementHandle statementHandle = 1;</code>
+     */
+    public org.apache.calcite.avatica.proto.Common.StatementHandleOrBuilder getStatementHandleOrBuilder() {
+      return getStatementHandle();
+    }
+
+    public static final int PARAMETER_VALUES_FIELD_NUMBER = 2;
+    private java.util.List<org.apache.calcite.avatica.proto.Common.TypedValue> parameterValues_;
+    /**
+     * <code>repeated .TypedValue parameter_values = 2;</code>
+     */
+    public java.util.List<org.apache.calcite.avatica.proto.Common.TypedValue> getParameterValuesList() {
+      return parameterValues_;
+    }
+    /**
+     * <code>repeated .TypedValue parameter_values = 2;</code>
+     */
+    public java.util.List<? extends org.apache.calcite.avatica.proto.Common.TypedValueOrBuilder> 
+        getParameterValuesOrBuilderList() {
+      return parameterValues_;
+    }
+    /**
+     * <code>repeated .TypedValue parameter_values = 2;</code>
+     */
+    public int getParameterValuesCount() {
+      return parameterValues_.size();
+    }
+    /**
+     * <code>repeated .TypedValue parameter_values = 2;</code>
+     */
+    public org.apache.calcite.avatica.proto.Common.TypedValue getParameterValues(int index) {
+      return parameterValues_.get(index);
+    }
+    /**
+     * <code>repeated .TypedValue parameter_values = 2;</code>
+     */
+    public org.apache.calcite.avatica.proto.Common.TypedValueOrBuilder getParameterValuesOrBuilder(
+        int index) {
+      return parameterValues_.get(index);
+    }
+
+    public static final int MAX_ROW_COUNT_FIELD_NUMBER = 3;
+    private long maxRowCount_;
+    /**
+     * <code>optional uint64 max_row_count = 3;</code>
+     */
+    public long getMaxRowCount() {
+      return maxRowCount_;
+    }
+
+    public static final int HAS_PARAMETER_VALUES_FIELD_NUMBER = 4;
+    private boolean hasParameterValues_;
+    /**
+     * <code>optional bool has_parameter_values = 4;</code>
+     */
+    public boolean getHasParameterValues() {
+      return hasParameterValues_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (statementHandle_ != null) {
+        output.writeMessage(1, getStatementHandle());
+      }
+      for (int i = 0; i < parameterValues_.size(); i++) {
+        output.writeMessage(2, parameterValues_.get(i));
+      }
+      if (maxRowCount_ != 0L) {
+        output.writeUInt64(3, maxRowCount_);
+      }
+      if (hasParameterValues_ != false) {
+        output.writeBool(4, hasParameterValues_);
+      }
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (statementHandle_ != null) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(1, getStatementHandle());
+      }
+      for (int i = 0; i < parameterValues_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(2, parameterValues_.get(i));
+      }
+      if (maxRowCount_ != 0L) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt64Size(3, maxRowCount_);
+      }
+      if (hasParameterValues_ != false) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(4, hasParameterValues_);
+      }
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    public static org.apache.calcite.avatica.proto.Requests.ExecuteRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.ExecuteRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.ExecuteRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.ExecuteRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.ExecuteRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.ExecuteRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.ExecuteRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.ExecuteRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.ExecuteRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.ExecuteRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return new Builder(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.apache.calcite.avatica.proto.Requests.ExecuteRequest prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code ExecuteRequest}
+     *
+     * <pre>
+     * Request for Meta#execute(Meta.ConnectionHandle, list, long)
+     * </pre>
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:ExecuteRequest)
+        org.apache.calcite.avatica.proto.Requests.ExecuteRequestOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.apache.calcite.avatica.proto.Requests.internal_static_ExecuteRequest_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.apache.calcite.avatica.proto.Requests.internal_static_ExecuteRequest_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.calcite.avatica.proto.Requests.ExecuteRequest.class, org.apache.calcite.avatica.proto.Requests.ExecuteRequest.Builder.class);
+      }
+
+      // Construct using org.apache.calcite.avatica.proto.Requests.ExecuteRequest.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getParameterValuesFieldBuilder();
+        }
+      }
+      public Builder clear() {
+        super.clear();
+        if (statementHandleBuilder_ == null) {
+          statementHandle_ = null;
+        } else {
+          statementHandle_ = null;
+          statementHandleBuilder_ = null;
+        }
+        if (parameterValuesBuilder_ == null) {
+          parameterValues_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000002);
+        } else {
+          parameterValuesBuilder_.clear();
+        }
+        maxRowCount_ = 0L;
+
+        hasParameterValues_ = false;
+
+        return this;
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.calcite.avatica.proto.Requests.internal_static_ExecuteRequest_descriptor;
+      }
+
+      public org.apache.calcite.avatica.proto.Requests.ExecuteRequest getDefaultInstanceForType() {
+        return org.apache.calcite.avatica.proto.Requests.ExecuteRequest.getDefaultInstance();
+      }
+
+      public org.apache.calcite.avatica.proto.Requests.ExecuteRequest build() {
+        org.apache.calcite.avatica.proto.Requests.ExecuteRequest result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public org.apache.calcite.avatica.proto.Requests.ExecuteRequest buildPartial() {
+        org.apache.calcite.avatica.proto.Requests.ExecuteRequest result = new org.apache.calcite.avatica.proto.Requests.ExecuteRequest(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (statementHandleBuilder_ == null) {
+          result.statementHandle_ = statementHandle_;
+        } else {
+          result.statementHandle_ = statementHandleBuilder_.build();
+        }
+        if (parameterValuesBuilder_ == null) {
+          if (((bitField0_ & 0x00000002) == 0x00000002)) {
+            parameterValues_ = java.util.Collections.unmodifiableList(parameterValues_);
+            bitField0_ = (bitField0_ & ~0x00000002);
+          }
+          result.parameterValues_ = parameterValues_;
+        } else {
+          result.parameterValues_ = parameterValuesBuilder_.build();
+        }
+        result.maxRowCount_ = maxRowCount_;
+        result.hasParameterValues_ = hasParameterValues_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.apache.calcite.avatica.proto.Requests.ExecuteRequest) {
+          return mergeFrom((org.apache.calcite.avatica.proto.Requests.ExecuteRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.apache.calcite.avatica.proto.Requests.ExecuteRequest other) {
+        if (other == org.apache.calcite.avatica.proto.Requests.ExecuteRequest.getDefaultInstance()) return this;
+        if (other.hasStatementHandle()) {
+          mergeStatementHandle(other.getStatementHandle());
+        }
+        if (parameterValuesBuilder_ == null) {
+          if (!other.parameterValues_.isEmpty()) {
+            if (parameterValues_.isEmpty()) {
+              parameterValues_ = other.parameterValues_;
+              bitField0_ = (bitField0_ & ~0x00000002);
+            } else {
+              ensureParameterValuesIsMutable();
+              parameterValues_.addAll(other.parameterValues_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.parameterValues_.isEmpty()) {
+            if (parameterValuesBuilder_.isEmpty()) {
+              parameterValuesBuilder_.dispose();
+              parameterValuesBuilder_ = null;
+              parameterValues_ = other.parameterValues_;
+              bitField0_ = (bitField0_ & ~0x00000002);
+              parameterValuesBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getParameterValuesFieldBuilder() : null;
+            } else {
+              parameterValuesBuilder_.addAllMessages(other.parameterValues_);
+            }
+          }
+        }
+        if (other.getMaxRowCount() != 0L) {
+          setMaxRowCount(other.getMaxRowCount());
+        }
+        if (other.getHasParameterValues() != false) {
+          setHasParameterValues(other.getHasParameterValues());
+        }
+        onChanged();
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.apache.calcite.avatica.proto.Requests.ExecuteRequest parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.calcite.avatica.proto.Requests.ExecuteRequest) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private org.apache.calcite.avatica.proto.Common.StatementHandle statementHandle_ = null;
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.calcite.avatica.proto.Common.StatementHandle, org.apache.calcite.avatica.proto.Common.StatementHandle.Builder, org.apache.calcite.avatica.proto.Common.StatementHandleOrBuilder> statementHandleBuilder_;
+      /**
+       * <code>optional .StatementHandle statementHandle = 1;</code>
+       */
+      public boolean hasStatementHandle() {
+        return statementHandleBuilder_ != null || statementHandle_ != null;
+      }
+      /**
+       * <code>optional .StatementHandle statementHandle = 1;</code>
+       */
+      public org.apache.calcite.avatica.proto.Common.StatementHandle getStatementHandle() {
+        if (statementHandleBuilder_ == null) {
+          return statementHandle_ == null ? org.apache.calcite.avatica.proto.Common.StatementHandle.getDefaultInstance() : statementHandle_;
+        } else {
+          return statementHandleBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .StatementHandle statementHandle = 1;</code>
+       */
+      public Builder setStatementHandle(org.apache.calcite.avatica.proto.Common.StatementHandle value) {
+        if (statementHandleBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          statementHandle_ = value;
+          onChanged();
+        } else {
+          statementHandleBuilder_.setMessage(value);
+        }
+
+        return this;
+      }
+      /**
+       * <code>optional .StatementHandle statementHandle = 1;</code>
+       */
+      public Builder setStatementHandle(
+          org.apache.calcite.avatica.proto.Common.StatementHandle.Builder builderForValue) {
+        if (statementHandleBuilder_ == null) {
+          statementHandle_ = builderForValue.build();
+          onChanged();
+        } else {
+          statementHandleBuilder_.setMessage(builderForValue.build());
+        }
+
+        return this;
+      }
+      /**
+       * <code>optional .StatementHandle statementHandle = 1;</code>
+       */
+      public Builder mergeStatementHandle(org.apache.calcite.avatica.proto.Common.StatementHandle value) {
+        if (statementHandleBuilder_ == null) {
+          if (statementHandle_ != null) {
+            statementHandle_ =
+              org.apache.calcite.avatica.proto.Common.StatementHandle.newBuilder(statementHandle_).mergeFrom(value).buildPartial();
+          } else {
+            statementHandle_ = value;
+          }
+          onChanged();
+        } else {
+          statementHandleBuilder_.mergeFrom(value);
+        }
+
+        return this;
+      }
+      /**
+       * <code>optional .StatementHandle statementHandle = 1;</code>
+       */
+      public Builder clearStatementHandle() {
+        if (statementHandleBuilder_ == null) {
+          statementHandle_ = null;
+          onChanged();
+        } else {
+          statementHandle_ = null;
+          statementHandleBuilder_ = null;
+        }
+
+        return this;
+      }
+      /**
+       * <code>optional .StatementHandle statementHandle = 1;</code>
+       */
+      public org.apache.calcite.avatica.proto.Common.StatementHandle.Builder getStatementHandleBuilder() {
+        
+        onChanged();
+        return getStatementHandleFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .StatementHandle statementHandle = 1;</code>
+       */
+      public org.apache.calcite.avatica.proto.Common.StatementHandleOrBuilder getStatementHandleOrBuilder() {
+        if (statementHandleBuilder_ != null) {
+          return statementHandleBuilder_.getMessageOrBuilder();
+        } else {
+          return statementHandle_ == null ?
+              org.apache.calcite.avatica.proto.Common.StatementHandle.getDefaultInstance() : statementHandle_;
+        }
+      }
+      /**
+       * <code>optional .StatementHandle statementHandle = 1;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.calcite.avatica.proto.Common.StatementHandle, org.apache.calcite.avatica.proto.Common.StatementHandle.Builder, org.apache.calcite.avatica.proto.Common.StatementHandleOrBuilder> 
+          getStatementHandleFieldBuilder() {
+        if (statementHandleBuilder_ == null) {
+          statementHandleBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              org.apache.calcite.avatica.proto.Common.StatementHandle, org.apache.calcite.avatica.proto.Common.StatementHandle.Builder, org.apache.calcite.avatica.proto.Common.StatementHandleOrBuilder>(
+                  getStatementHandle(),
+                  getParentForChildren(),
+                  isClean());
+          statementHandle_ = null;
+        }
+        return statementHandleBuilder_;
+      }
+
+      private java.util.List<org.apache.calcite.avatica.proto.Common.TypedValue> parameterValues_ =
+        java.util.Collections.emptyList();
+      private void ensureParameterValuesIsMutable() {
+        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
+          parameterValues_ = new java.util.ArrayList<org.apache.calcite.avatica.proto.Common.TypedValue>(parameterValues_);
+          bitField0_ |= 0x00000002;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilder<
+          org.apache.calcite.avatica.proto.Common.TypedValue, org.apache.calcite.avatica.proto.Common.TypedValue.Builder, org.apache.calcite.avatica.proto.Common.TypedValueOrBuilder> parameterValuesBuilder_;
+
+      /**
+       * <code>repeated .TypedValue parameter_values = 2;</code>
+       */
+      public java.util.List<org.apache.calcite.avatica.proto.Common.TypedValue> getParameterValuesList() {
+        if (parameterValuesBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(parameterValues_);
+        } else {
+          return parameterValuesBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 2;</code>
+       */
+      public int getParameterValuesCount() {
+        if (parameterValuesBuilder_ == null) {
+          return parameterValues_.size();
+        } else {
+          return parameterValuesBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 2;</code>
+       */
+      public org.apache.calcite.avatica.proto.Common.TypedValue getParameterValues(int index) {
+        if (parameterValuesBuilder_ == null) {
+          return parameterValues_.get(index);
+        } else {
+          return parameterValuesBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 2;</code>
+       */
+      public Builder setParameterValues(
+          int index, org.apache.calcite.avatica.proto.Common.TypedValue value) {
+        if (parameterValuesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureParameterValuesIsMutable();
+          parameterValues_.set(index, value);
+          onChanged();
+        } else {
+          parameterValuesBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 2;</code>
+       */
+      public Builder setParameterValues(
+          int index, org.apache.calcite.avatica.proto.Common.TypedValue.Builder builderForValue) {
+        if (parameterValuesBuilder_ == null) {
+          ensureParameterValuesIsMutable();
+          parameterValues_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          parameterValuesBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 2;</code>
+       */
+      public Builder addParameterValues(org.apache.calcite.avatica.proto.Common.TypedValue value) {
+        if (parameterValuesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureParameterValuesIsMutable();
+          parameterValues_.add(value);
+          onChanged();
+        } else {
+          parameterValuesBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 2;</code>
+       */
+      public Builder addParameterValues(
+          int index, org.apache.calcite.avatica.proto.Common.TypedValue value) {
+        if (parameterValuesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureParameterValuesIsMutable();
+          parameterValues_.add(index, value);
+          onChanged();
+        } else {
+          parameterValuesBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 2;</code>
+       */
+      public Builder addParameterValues(
+          org.apache.calcite.avatica.proto.Common.TypedValue.Builder builderForValue) {
+        if (parameterValuesBuilder_ == null) {
+          ensureParameterValuesIsMutable();
+          parameterValues_.add(builderForValue.build());
+          onChanged();
+        } else {
+          parameterValuesBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 2;</code>
+       */
+      public Builder addParameterValues(
+          int index, org.apache.calcite.avatica.proto.Common.TypedValue.Builder builderForValue) {
+        if (parameterValuesBuilder_ == null) {
+          ensureParameterValuesIsMutable();
+          parameterValues_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          parameterValuesBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 2;</code>
+       */
+      public Builder addAllParameterValues(
+          java.lang.Iterable<? extends org.apache.calcite.avatica.proto.Common.TypedValue> values) {
+        if (parameterValuesBuilder_ == null) {
+          ensureParameterValuesIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, parameterValues_);
+          onChanged();
+        } else {
+          parameterValuesBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 2;</code>
+       */
+      public Builder clearParameterValues() {
+        if (parameterValuesBuilder_ == null) {
+          parameterValues_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000002);
+          onChanged();
+        } else {
+          parameterValuesBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 2;</code>
+       */
+      public Builder removeParameterValues(int index) {
+        if (parameterValuesBuilder_ == null) {
+          ensureParameterValuesIsMutable();
+          parameterValues_.remove(index);
+          onChanged();
+        } else {
+          parameterValuesBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 2;</code>
+       */
+      public org.apache.calcite.avatica.proto.Common.TypedValue.Builder getParameterValuesBuilder(
+          int index) {
+        return getParameterValuesFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 2;</code>
+       */
+      public org.apache.calcite.avatica.proto.Common.TypedValueOrBuilder getParameterValuesOrBuilder(
+          int index) {
+        if (parameterValuesBuilder_ == null) {
+          return parameterValues_.get(index);  } else {
+          return parameterValuesBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 2;</code>
+       */
+      public java.util.List<? extends org.apache.calcite.avatica.proto.Common.TypedValueOrBuilder> 
+           getParameterValuesOrBuilderList() {
+        if (parameterValuesBuilder_ != null) {
+          return parameterValuesBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(parameterValues_);
+        }
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 2;</code>
+       */
+      public org.apache.calcite.avatica.proto.Common.TypedValue.Builder addParameterValuesBuilder() {
+        return getParameterValuesFieldBuilder().addBuilder(
+            org.apache.calcite.avatica.proto.Common.TypedValue.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 2;</code>
+       */
+      public org.apache.calcite.avatica.proto.Common.TypedValue.Builder addParameterValuesBuilder(
+          int index) {
+        return getParameterValuesFieldBuilder().addBuilder(
+            index, org.apache.calcite.avatica.proto.Common.TypedValue.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 2;</code>
+       */
+      public java.util.List<org.apache.calcite.avatica.proto.Common.TypedValue.Builder> 
+           getParameterValuesBuilderList() {
+        return getParameterValuesFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          org.apache.calcite.avatica.proto.Common.TypedValue, org.apache.calcite.avatica.proto.Common.TypedValue.Builder, org.apache.calcite.avatica.proto.Common.TypedValueOrBuilder> 
+          getParameterValuesFieldBuilder() {
+        if (parameterValuesBuilder_ == null) {
+          parameterValuesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              org.apache.calcite.avatica.proto.Common.TypedValue, org.apache.calcite.avatica.proto.Common.TypedValue.Builder, org.apache.calcite.avatica.proto.Common.TypedValueOrBuilder>(
+                  parameterValues_,
+                  ((bitField0_ & 0x00000002) == 0x00000002),
+                  getParentForChildren(),
+                  isClean());
+          parameterValues_ = null;
+        }
+        return parameterValuesBuilder_;
+      }
+
+      private long maxRowCount_ ;
+      /**
+       * <code>optional uint64 max_row_count = 3;</code>
+       */
+      public long getMaxRowCount() {
+        return maxRowCount_;
+      }
+      /**
+       * <code>optional uint64 max_row_count = 3;</code>
+       */
+      public Builder setMaxRowCount(long value) {
+        
+        maxRowCount_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional uint64 max_row_count = 3;</code>
+       */
+      public Builder clearMaxRowCount() {
+        
+        maxRowCount_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private boolean hasParameterValues_ ;
+      /**
+       * <code>optional bool has_parameter_values = 4;</code>
+       */
+      public boolean getHasParameterValues() {
+        return hasParameterValues_;
+      }
+      /**
+       * <code>optional bool has_parameter_values = 4;</code>
+       */
+      public Builder setHasParameterValues(boolean value) {
+        
+        hasParameterValues_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bool has_parameter_values = 4;</code>
+       */
+      public Builder clearHasParameterValues() {
+        
+        hasParameterValues_ = false;
+        onChanged();
+        return this;
+      }
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return this;
+      }
+
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return this;
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:ExecuteRequest)
+    }
+
+    // @@protoc_insertion_point(class_scope:ExecuteRequest)
+    private static final org.apache.calcite.avatica.proto.Requests.ExecuteRequest defaultInstance;static {
+      defaultInstance = new org.apache.calcite.avatica.proto.Requests.ExecuteRequest();
+    }
+
+    public static org.apache.calcite.avatica.proto.Requests.ExecuteRequest getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public org.apache.calcite.avatica.proto.Requests.ExecuteRequest getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+  }
+
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_CatalogsRequest_descriptor;
   private static
@@ -8291,6 +8710,11 @@ package org.apache.calcite.avatica.proto;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_ConnectionSyncRequest_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_ExecuteRequest_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_ExecuteRequest_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -8315,19 +8739,21 @@ package org.apache.calcite.avatica.proto;
       "\001(\t\022\025\n\rmax_row_count\030\003 \001(\004\022\024\n\014statement_" +
       "id\030\004 \001(\r\"K\n\016PrepareRequest\022\025\n\rconnection" +
       "_id\030\001 \001(\t\022\013\n\003sql\030\002 \001(\t\022\025\n\rmax_row_count\030" +
-      "\003 \001(\004\"\255\001\n\014FetchRequest\022\025\n\rconnection_id\030" +
-      "\001 \001(\t\022\024\n\014statement_id\030\002 \001(\r\022\016\n\006offset\030\003 " +
-      "\001(\004\022\033\n\023fetch_max_row_count\030\004 \001(\r\022%\n\020para" +
-      "meter_values\030\005 \003(\0132\013.TypedValue\022\034\n\024has_p" +
-      "arameter_values\030\006 \001(\010\"/\n\026CreateStatement",
-      "Request\022\025\n\rconnection_id\030\001 \001(\t\"D\n\025CloseS" +
-      "tatementRequest\022\025\n\rconnection_id\030\001 \001(\t\022\024" +
-      "\n\014statement_id\030\002 \001(\r\"/\n\026CloseConnectionR" +
-      "equest\022\025\n\rconnection_id\030\001 \001(\t\"Y\n\025Connect" +
-      "ionSyncRequest\022\025\n\rconnection_id\030\001 \001(\t\022)\n" +
-      "\nconn_props\030\002 \001(\0132\025.ConnectionProperties" +
-      "B\"\n org.apache.calcite.avatica.protob\006pr" +
-      "oto3"
+      "\003 \001(\004\"h\n\014FetchRequest\022\025\n\rconnection_id\030\001" +
+      " \001(\t\022\024\n\014statement_id\030\002 \001(\r\022\016\n\006offset\030\003 \001" +
+      "(\004\022\033\n\023fetch_max_row_count\030\004 \001(\r\"/\n\026Creat" +
+      "eStatementRequest\022\025\n\rconnection_id\030\001 \001(\t" +
+      "\"D\n\025CloseStatementRequest\022\025\n\rconnection_",
+      "id\030\001 \001(\t\022\024\n\014statement_id\030\002 \001(\r\"/\n\026CloseC" +
+      "onnectionRequest\022\025\n\rconnection_id\030\001 \001(\t\"" +
+      "Y\n\025ConnectionSyncRequest\022\025\n\rconnection_i" +
+      "d\030\001 \001(\t\022)\n\nconn_props\030\002 \001(\0132\025.Connection" +
+      "Properties\"\227\001\n\016ExecuteRequest\022)\n\017stateme" +
+      "ntHandle\030\001 \001(\0132\020.StatementHandle\022%\n\020para" +
+      "meter_values\030\002 \003(\0132\013.TypedValue\022\025\n\rmax_r" +
+      "ow_count\030\003 \001(\004\022\034\n\024has_parameter_values\030\004" +
+      " \001(\010B\"\n org.apache.calcite.avatica.proto" +
+      "b\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -8401,7 +8827,7 @@ package org.apache.calcite.avatica.proto;
     internal_static_FetchRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_FetchRequest_descriptor,
-        new java.lang.String[] { "ConnectionId", "StatementId", "Offset", "FetchMaxRowCount", "ParameterValues", "HasParameterValues", });
+        new java.lang.String[] { "ConnectionId", "StatementId", "Offset", "FetchMaxRowCount", });
     internal_static_CreateStatementRequest_descriptor =
       getDescriptor().getMessageTypes().get(10);
     internal_static_CreateStatementRequest_fieldAccessorTable = new
@@ -8426,6 +8852,12 @@ package org.apache.calcite.avatica.proto;
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_ConnectionSyncRequest_descriptor,
         new java.lang.String[] { "ConnectionId", "ConnProps", });
+    internal_static_ExecuteRequest_descriptor =
+      getDescriptor().getMessageTypes().get(14);
+    internal_static_ExecuteRequest_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_ExecuteRequest_descriptor,
+        new java.lang.String[] { "StatementHandle", "ParameterValues", "MaxRowCount", "HasParameterValues", });
     org.apache.calcite.avatica.proto.Common.getDescriptor();
   }
 

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/AbstractService.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/AbstractService.java
@@ -43,7 +43,7 @@ public abstract class AbstractService implements Service {
     }
     return new Meta.Signature(columns, signature.sql,
         signature.parameters, signature.internalParameters,
-        signature.cursorFactory);
+        signature.cursorFactory, signature.statementType);
   }
 
   ColumnMetaData finagle(ColumnMetaData column) {

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/JsonService.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/JsonService.java
@@ -132,6 +132,14 @@ public abstract class JsonService extends AbstractService {
     }
   }
 
+  public ExecuteResponse apply(ExecuteRequest request) {
+    try {
+      return finagle(decode(apply(encode(request)), ExecuteResponse.class));
+    } catch (IOException e) {
+      throw handle(e);
+    }
+  }
+
   public CreateStatementResponse apply(CreateStatementRequest request) {
     try {
       return decode(apply(encode(request)), CreateStatementResponse.class);

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/LocalService.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/LocalService.java
@@ -51,8 +51,13 @@ public class LocalService implements Service {
           resultSet.statementId, resultSet.ownStatement, null, null,
           resultSet.updateCount);
     }
+
+    Meta.Signature signature = resultSet.signature;
     Meta.CursorFactory cursorFactory = resultSet.signature.cursorFactory;
+    Meta.Frame frame = null;
+    int updatCount = -1;
     final List<Object> list;
+
     if (resultSet.firstFrame != null) {
       list = list(resultSet.firstFrame.rows);
       switch (cursorFactory.style) {
@@ -62,19 +67,41 @@ public class LocalService implements Service {
       case MAP:
       case LIST:
         break;
+      case RECORD:
+        cursorFactory = Meta.CursorFactory.LIST;
+        break;
       default:
         cursorFactory = Meta.CursorFactory.map(cursorFactory.fieldNames);
       }
+
+      boolean done;
+      if (resultSet.firstFrame == null) {
+        done = false;
+      } else {
+        done = resultSet.firstFrame.done;
+      }
+
+      frame = new Meta.Frame(0, done, list);
+      updatCount = -1;
+
+      if (signature.statementType != null) {
+        if (signature.statementType.canUpdate()) {
+          frame = null;
+          updatCount = ((Number) ((List) list.get(0)).get(0)).intValue();
+        }
+      }
     } else {
       //noinspection unchecked
+      list = (List<Object>) (List) list2(resultSet);
       cursorFactory = Meta.CursorFactory.LIST;
     }
-    Meta.Signature signature = resultSet.signature;
+
     if (cursorFactory != resultSet.signature.cursorFactory) {
       signature = signature.setCursorFactory(cursorFactory);
     }
+
     return new ResultSetResponse(resultSet.connectionId, resultSet.statementId,
-        resultSet.ownStatement, signature, resultSet.firstFrame, -1);
+        resultSet.ownStatement, signature, frame, updatCount);
   }
 
   private List<List<Object>> list2(Meta.MetaResultSet resultSet) {
@@ -166,10 +193,20 @@ public class LocalService implements Service {
         request.connectionId, request.statementId, null);
     final Meta.Frame frame =
         meta.fetch(h,
-            request.parameterValues,
             request.offset,
             request.fetchMaxRowCount);
     return new FetchResponse(frame);
+  }
+
+  public ExecuteResponse apply(ExecuteRequest request) {
+    final Meta.ExecuteResult executeResult = meta.execute(request.statementHandle,
+        request.parameterValues, request.maxRowCount);
+
+    final List<ResultSetResponse> results = new ArrayList<>();
+    for (Meta.MetaResultSet metaResultSet : executeResult.resultSets) {
+      results.add(toResponse(metaResultSet));
+    }
+    return new ExecuteResponse(results);
   }
 
   public CreateStatementResponse apply(CreateStatementRequest request) {

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/MockProtobufService.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/MockProtobufService.java
@@ -61,7 +61,7 @@ public class MockProtobufService extends ProtobufService {
                 Arrays.<ColumnMetaData>asList(
                     MetaImpl.columnMetaData("C1", 0, Integer.class),
                     MetaImpl.columnMetaData("C2", 1, String.class)),
-                null, null, Meta.CursorFactory.ARRAY),
+                null, null, Meta.CursorFactory.ARRAY, Meta.StatementType.SELECT),
             Meta.Frame.create(0, true,
                 Arrays.<Object>asList(new Object[] {1, "a"},
                     new Object[] {null, "b"}, new Object[] {3, "c"})), -1));
@@ -76,7 +76,7 @@ public class MockProtobufService extends ProtobufService {
                     MetaImpl.columnMetaData("C1", 0, Integer.class),
                     MetaImpl.columnMetaData("C2", 1, String.class)),
                 null, Collections.<AvaticaParameter>emptyList(),
-                Meta.CursorFactory.ARRAY),
+                Meta.CursorFactory.ARRAY, Meta.StatementType.SELECT),
             null, -1));
 
     MAPPING = Collections.unmodifiableMap(mappings);

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/ProtobufService.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/ProtobufService.java
@@ -86,6 +86,10 @@ public abstract class ProtobufService extends AbstractService {
     return (DatabasePropertyResponse) _apply(request);
   }
 
+  @Override public ExecuteResponse apply(ExecuteRequest request) {
+    return (ExecuteResponse) _apply(request);
+  }
+
   /**
    * Determines whether the given message has the field, denoted by the provided number, set.
    *

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/ProtobufTranslationImpl.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/ProtobufTranslationImpl.java
@@ -24,6 +24,7 @@ import org.apache.calcite.avatica.proto.Requests.ColumnsRequest;
 import org.apache.calcite.avatica.proto.Requests.ConnectionSyncRequest;
 import org.apache.calcite.avatica.proto.Requests.CreateStatementRequest;
 import org.apache.calcite.avatica.proto.Requests.DatabasePropertyRequest;
+import org.apache.calcite.avatica.proto.Requests.ExecuteRequest;
 import org.apache.calcite.avatica.proto.Requests.FetchRequest;
 import org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteRequest;
 import org.apache.calcite.avatica.proto.Requests.PrepareRequest;
@@ -96,6 +97,8 @@ public class ProtobufTranslationImpl implements ProtobufTranslation {
         new RequestTranslator(TableTypesRequest.PARSER, new Service.TableTypesRequest()));
     reqParsers.put(TypeInfoRequest.class.getName(),
         new RequestTranslator(TypeInfoRequest.PARSER, new Service.TypeInfoRequest()));
+    reqParsers.put(ExecuteRequest.class.getName(),
+        new RequestTranslator(ExecuteRequest.PARSER, new Service.ExecuteRequest()));
 
     REQUEST_PARSERS = Collections.unmodifiableMap(reqParsers);
 

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/Service.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/Service.java
@@ -47,6 +47,7 @@ public interface Service {
   ResultSetResponse apply(TypeInfoRequest request);
   ResultSetResponse apply(ColumnsRequest request);
   PrepareResponse apply(PrepareRequest request);
+  ExecuteResponse apply(ExecuteRequest request);
   ExecuteResponse apply(PrepareAndExecuteRequest request);
   FetchResponse apply(FetchRequest request);
   CreateStatementResponse apply(CreateStatementRequest request);
@@ -72,6 +73,7 @@ public interface Service {
       @JsonSubTypes.Type(value = TableTypesRequest.class, name = "getTableTypes"),
       @JsonSubTypes.Type(value = TypeInfoRequest.class, name = "getTypeInfo"),
       @JsonSubTypes.Type(value = ColumnsRequest.class, name = "getColumns"),
+      @JsonSubTypes.Type(value = ExecuteRequest.class, name = "execute"),
       @JsonSubTypes.Type(value = PrepareRequest.class, name = "prepare"),
       @JsonSubTypes.Type(value = PrepareAndExecuteRequest.class,
           name = "prepareAndExecute"),
@@ -887,6 +889,122 @@ public interface Service {
     }
   }
 
+  /** Request for
+   * {@link org.apache.calcite.avatica.Meta#execute}. */
+  class ExecuteRequest extends Request {
+    public final Meta.StatementHandle statementHandle;
+    public final List<TypedValue> parameterValues;
+    public final long maxRowCount;
+
+    ExecuteRequest() {
+      statementHandle = null;
+      parameterValues = null;
+      maxRowCount = 0;
+    }
+
+    @JsonCreator
+    public ExecuteRequest(
+        @JsonProperty("statementHandle") Meta.StatementHandle statementHandle,
+        @JsonProperty("parameterValues") List<TypedValue> parameterValues,
+        @JsonProperty("maxRowCount") long maxRowCount) {
+      this.statementHandle = statementHandle;
+      this.parameterValues = parameterValues;
+      this.maxRowCount = maxRowCount;
+    }
+
+    @Override ExecuteResponse accept(Service service) {
+      return service.apply(this);
+    }
+
+    @Override ExecuteRequest deserialize(Message genericMsg) {
+      if (!(genericMsg instanceof Requests.ExecuteRequest)) {
+        throw new IllegalArgumentException(
+            "Expected ExecuteRequest, but got " + genericMsg.getClass().getName());
+      }
+
+      final Requests.ExecuteRequest msg = (Requests.ExecuteRequest) genericMsg;
+      final Descriptor desc = msg.getDescriptorForType();
+
+      Meta.StatementHandle statemetnHandle = null;
+      if (ProtobufService.hasField(msg, desc,
+          Requests.ExecuteRequest.STATEMENTHANDLE_FIELD_NUMBER)) {
+        statemetnHandle = Meta.StatementHandle.fromProto(msg.getStatementHandle());
+      }
+
+      List<TypedValue> values = null;
+      if (msg.getHasParameterValues()) {
+        values = new ArrayList<>(msg.getParameterValuesCount());
+        for (Common.TypedValue valueProto : msg.getParameterValuesList()) {
+          values.add(TypedValue.fromProto(valueProto));
+        }
+      }
+
+      return new ExecuteRequest(statemetnHandle, values, msg.getMaxRowCount());
+    }
+
+    @Override Requests.ExecuteRequest serialize() {
+      Requests.ExecuteRequest.Builder builder = Requests.ExecuteRequest.newBuilder();
+
+      if (null != statementHandle) {
+        builder.setStatementHandle(statementHandle.toProto());
+      }
+
+      if (null != parameterValues) {
+        builder.setHasParameterValues(true);
+        for (TypedValue paramValue : parameterValues) {
+          if (paramValue == null) {
+            builder.addParameterValues(TypedValue.NULL.toProto());
+          } else {
+            builder.addParameterValues(paramValue.toProto());
+          }
+        }
+      } else {
+        builder.setHasParameterValues(false);
+      }
+
+      builder.setMaxRowCount(maxRowCount);
+
+      return builder.build();
+    }
+
+    @Override public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + ((statementHandle == null) ? 0 : statementHandle.hashCode());
+      result = prime * result + ((parameterValues == null) ? 0 : parameterValues.hashCode());
+      result = prime * result + (int) (maxRowCount ^ (maxRowCount >>> 32));
+      return 0;
+    }
+
+    @Override public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof ExecuteRequest) {
+        ExecuteRequest other = (ExecuteRequest) o;
+
+        if (statementHandle == null) {
+          if (other.statementHandle != null) {
+            return false;
+          }
+        } else if (!statementHandle.equals(other.statementHandle)) {
+          return false;
+        }
+
+        if (null == parameterValues) {
+          if (null != other.parameterValues) {
+            return false;
+          }
+        } else if (!parameterValues.equals(other.parameterValues)) {
+          return false;
+        }
+
+        return maxRowCount == other.maxRowCount;
+      }
+      return false;
+    }
+  }
+
   /** Response to a
    * {@link org.apache.calcite.avatica.remote.Service.PrepareAndExecuteRequest}. */
   class ExecuteResponse extends Response {
@@ -1128,7 +1246,7 @@ public interface Service {
   }
 
   /** Request for
-   * {@link Meta#fetch(Meta.StatementHandle, List, long, int)}. */
+   * {@link Meta#fetch}. */
   class FetchRequest extends Request {
     public final String connectionId;
     public final int statementId;
@@ -1136,28 +1254,22 @@ public interface Service {
     /** Maximum number of rows to be returned in the frame. Negative means no
      * limit. */
     public final int fetchMaxRowCount;
-    /** A list of parameter values, if statement is to be executed; otherwise
-     * null. */
-    public final List<TypedValue> parameterValues;
 
     FetchRequest() {
       connectionId = null;
       statementId = 0;
       offset = 0;
       fetchMaxRowCount = 0;
-      parameterValues = null;
     }
 
     @JsonCreator
     public FetchRequest(
         @JsonProperty("connectionId") String connectionId,
         @JsonProperty("statementId") int statementId,
-        @JsonProperty("parameterValues") List<TypedValue> parameterValues,
         @JsonProperty("offset") long offset,
         @JsonProperty("fetchMaxRowCount") int fetchMaxRowCount) {
       this.connectionId = connectionId;
       this.statementId = statementId;
-      this.parameterValues = parameterValues;
       this.offset = offset;
       this.fetchMaxRowCount = fetchMaxRowCount;
     }
@@ -1175,36 +1287,17 @@ public interface Service {
       final Requests.FetchRequest msg = (Requests.FetchRequest) genericMsg;
       final Descriptor desc = msg.getDescriptorForType();
 
-      // Cannot determine if a value was set for a repeated field. Must use an extra boolean
-      // parameter to distinguish an empty list and a null list of ParameterValues.
-      List<TypedValue> values = null;
-      if (msg.getHasParameterValues()) {
-        values = new ArrayList<>(msg.getParameterValuesCount());
-        for (Common.TypedValue valueProto : msg.getParameterValuesList()) {
-          values.add(TypedValue.fromProto(valueProto));
-        }
-      }
-
       String connectionId = null;
       if (ProtobufService.hasField(msg, desc, Requests.FetchRequest.CONNECTION_ID_FIELD_NUMBER)) {
         connectionId = msg.getConnectionId();
       }
 
-      return new FetchRequest(connectionId, msg.getStatementId(), values, msg.getOffset(),
+      return new FetchRequest(connectionId, msg.getStatementId(), msg.getOffset(),
           msg.getFetchMaxRowCount());
     }
 
     @Override Requests.FetchRequest serialize() {
       Requests.FetchRequest.Builder builder = Requests.FetchRequest.newBuilder();
-
-      if (null != parameterValues) {
-        builder.setHasParameterValues(true);
-        for (TypedValue paramValue : parameterValues) {
-          builder.addParameterValues(paramValue.toProto());
-        }
-      } else {
-        builder.setHasParameterValues(false);
-      }
 
       if (null != connectionId) {
         builder.setConnectionId(connectionId);
@@ -1223,7 +1316,6 @@ public interface Service {
       result = prime * result + ((connectionId == null) ? 0 : connectionId.hashCode());
       result = prime * result + fetchMaxRowCount;
       result = prime * result + (int) (offset ^ (offset >>> 32));
-      result = prime * result + ((parameterValues == null) ? 0 : parameterValues.hashCode());
       result = prime * result + statementId;
       return result;
     }
@@ -1243,14 +1335,6 @@ public interface Service {
           if (!connectionId.equals(other.connectionId)) {
             return false;
           }
-        }
-
-        if (null == parameterValues) {
-          if (null != other.parameterValues) {
-            return false;
-          }
-        } else if (!parameterValues.equals(other.parameterValues)) {
-          return false;
         }
 
         return offset == other.offset && fetchMaxRowCount == other.fetchMaxRowCount;

--- a/avatica/src/main/java/org/apache/calcite/avatica/util/AbstractCursor.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/util/AbstractCursor.java
@@ -778,9 +778,15 @@ public abstract class AbstractCursor implements Cursor {
       super(getter);
     }
 
+    //FIXME: Protobuf gets byte[]
     public byte[] getBytes() {
-      final ByteString o = (ByteString) getObject();
-      return o == null ? null : o.getBytes();
+      Object obj = getObject();
+      try {
+        final ByteString o = (ByteString) obj;
+        return o == null ? null : o.getBytes();
+      } catch (Exception ex) {
+        return obj == null ? null : (byte[]) obj;
+      }
     }
   }
 

--- a/avatica/src/main/protobuf/common.proto
+++ b/avatica/src/main/protobuf/common.proto
@@ -44,6 +44,23 @@ message Signature {
   string sql = 2;
   repeated AvaticaParameter parameters = 3;
   CursorFactory cursor_factory = 4;
+  StatementType statementType = 5;
+}
+
+// Has to be consistent with Meta.StatementType
+enum StatementType {
+  SELECT = 0;
+  INSERT = 1;
+  UPDATE = 2;
+  DELETE = 3;
+  UPSERT = 4;
+  MERGE = 5;
+  OTHER_DML = 6;
+  CREATE = 7;
+  DROP = 8;
+  ALTER = 9;
+  OTHER_DDL = 10;
+  CALL = 11;
 }
 
 message ColumnMetaData {

--- a/avatica/src/main/protobuf/requests.proto
+++ b/avatica/src/main/protobuf/requests.proto
@@ -86,8 +86,6 @@ message FetchRequest {
   uint32 statement_id = 2;
   uint64 offset = 3;
   uint32 fetch_max_row_count = 4; // Maximum number of rows to be returned in the frame. Negative means no limit.
-  repeated TypedValue parameter_values = 5; // List of parameter values if statement is to be executed. Else, none.
-  bool has_parameter_values = 6; // Having an empty list of param values is distinct from a null param list
 }
 
 // Request for Meta#createStatement(Meta.ConnectionHandle)
@@ -110,4 +108,13 @@ message ConnectionSyncRequest {
   string connection_id = 1;
   ConnectionProperties conn_props = 2;
 }
+
+// Request for Meta#execute(Meta.ConnectionHandle, list, long)
+message ExecuteRequest {
+  StatementHandle statementHandle = 1;
+  repeated TypedValue parameter_values = 2;
+  uint64 max_row_count = 3;
+  bool has_parameter_values = 4;
+}
+
 

--- a/avatica/src/test/java/org/apache/calcite/avatica/remote/ProtobufHandlerTest.java
+++ b/avatica/src/test/java/org/apache/calcite/avatica/remote/ProtobufHandlerTest.java
@@ -74,7 +74,7 @@ public class ProtobufHandlerTest {
     Requests.FetchRequest protoRequest = Requests.FetchRequest.newBuilder()
         .setConnectionId(connectionId).setStatementId(statementId)
         .setOffset(offset).setFetchMaxRowCount(fetchMaxRowCount)
-        .addAllParameterValues(values).build();
+        .build();
     byte[] serializedRequest = protoRequest.toByteArray();
 
     FetchRequest request = new FetchRequest().deserialize(protoRequest);

--- a/avatica/src/test/java/org/apache/calcite/avatica/remote/ProtobufTranslationImplTest.java
+++ b/avatica/src/test/java/org/apache/calcite/avatica/remote/ProtobufTranslationImplTest.java
@@ -175,7 +175,7 @@ public class ProtobufTranslationImplTest<T> {
     List<TypedValue> paramValues =
         Arrays.asList(TypedValue.create(Rep.BOOLEAN.name(), Boolean.TRUE),
             TypedValue.create(Rep.STRING.name(), "string"));
-    FetchRequest fetchRequest = new FetchRequest("connectionId", Integer.MAX_VALUE, paramValues,
+    FetchRequest fetchRequest = new FetchRequest("connectionId", Integer.MAX_VALUE,
         Long.MAX_VALUE, Integer.MAX_VALUE);
     requests.add(fetchRequest);
 
@@ -231,7 +231,8 @@ public class ProtobufTranslationImplTest<T> {
     rows.add(new Object[] {"str_value", 50});
 
     // Create the signature and frame using the metadata and values
-    Signature signature = Signature.create(columns, "sql", params, cursorFactory);
+    Signature signature = Signature.create(columns, "sql", params, cursorFactory,
+        Meta.StatementType.SELECT);
     Frame frame = Frame.create(Integer.MAX_VALUE, true, rows);
 
     // And then create a ResultSetResponse

--- a/avatica/src/test/java/org/apache/calcite/avatica/test/JsonHandlerTest.java
+++ b/avatica/src/test/java/org/apache/calcite/avatica/test/JsonHandlerTest.java
@@ -22,13 +22,13 @@ import org.apache.calcite.avatica.remote.LocalJsonService;
 import org.apache.calcite.avatica.remote.Service;
 import org.apache.calcite.avatica.remote.TypedValue;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -96,6 +96,10 @@ public class JsonHandlerTest {
     @Override public DatabasePropertyResponse apply(DatabasePropertyRequest request) {
       return null;
     }
+
+    @Override public ExecuteResponse apply(ExecuteRequest request) {
+      return null;
+    }
   }
 
 
@@ -112,16 +116,11 @@ public class JsonHandlerTest {
     }
 
     @Override public FetchResponse apply(FetchRequest request) {
-      assertEquals(expectedParameterValues.size(), request.parameterValues.size());
-      for (int i = 0; i < expectedParameterValues.size(); i++) {
-        assertEquals(expectedParameterValues.get(i).type, request.parameterValues.get(i).type);
-        assertEquals(expectedParameterValues.get(i).value, request.parameterValues.get(i).value);
-      }
-      expectedParameterValues.clear();
       return null;
     }
   }
 
+  @Ignore // Mark as ignore because fetch does not support parameters anymore
   @Test public void testFetchRequestWithNumberParameter() {
     final List<TypedValue> expectedParameterValues = new ArrayList<>();
     final Service service = new ParameterValuesCheckingService(expectedParameterValues);

--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
@@ -25,6 +25,7 @@ import org.apache.calcite.avatica.AvaticaStatement;
 import org.apache.calcite.avatica.Helper;
 import org.apache.calcite.avatica.InternalProperty;
 import org.apache.calcite.avatica.Meta;
+import org.apache.calcite.avatica.MetaImpl;
 import org.apache.calcite.avatica.UnregisteredDriver;
 import org.apache.calcite.avatica.remote.TypedValue;
 import org.apache.calcite.config.CalciteConnectionConfig;
@@ -190,8 +191,12 @@ abstract class CalciteConnectionImpl
     try {
       final Meta.Signature signature =
           parseQuery(query, new ContextImpl(this), -1);
-      return (CalcitePreparedStatement) factory.newPreparedStatement(this, null,
-          signature, resultSetType, resultSetConcurrency, resultSetHoldability);
+      final CalcitePreparedStatement calcitePreparedStatement =
+          (CalcitePreparedStatement) factory.newPreparedStatement(this, null,
+              signature, resultSetType, resultSetConcurrency, resultSetHoldability);
+      server.addStatement(this, calcitePreparedStatement.handle);
+      server.getStatement(calcitePreparedStatement.handle).setSignature(signature);
+      return calcitePreparedStatement;
     } catch (Exception e) {
       throw Helper.INSTANCE.createException(
           "Error while preparing statement [" + query.sql + "]", e);
@@ -261,6 +266,11 @@ abstract class CalciteConnectionImpl
     AvaticaStatement statement = lookupStatement(handle);
     final List<TypedValue> parameterValues =
         TROJAN.getParameterValues(statement);
+
+    if (MetaImpl.checkParameterValueHasNull(parameterValues)) {
+      throw new SQLException("exception while executing query: unbound parameter");
+    }
+
     for (Ord<TypedValue> o : Ord.zip(parameterValues)) {
       map.put("?" + o.i, o.e.toLocal());
     }

--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteMetaImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteMetaImpl.java
@@ -197,7 +197,7 @@ public class CalciteMetaImpl extends MetaImpl {
           new CalcitePrepare.CalciteSignature<Object>("",
               ImmutableList.<AvaticaParameter>of(), internalParameters, null,
               columns, cursorFactory, ImmutableList.<RelCollation>of(), -1,
-              null) {
+              null, Meta.StatementType.SELECT) {
             @Override public Enumerable<Object> enumerable(
                 DataContext dataContext) {
               return Linq4j.asEnumerable(firstFrame.rows);
@@ -534,7 +534,7 @@ public class CalciteMetaImpl extends MetaImpl {
           (CalcitePrepare.CalciteSignature<Object>) signature;
       return getConnection().enumerable(handle, calciteSignature);
     } catch (SQLException e) {
-      throw new RuntimeException(e);
+      throw new RuntimeException(e.getMessage());
     }
   }
 
@@ -575,15 +575,15 @@ public class CalciteMetaImpl extends MetaImpl {
     // TODO: share code with prepare and createIterable
   }
 
-  @Override public Frame fetch(StatementHandle h, List<TypedValue> parameterValues,
-      long offset, int fetchMaxRowCount) {
+  @Override public Frame fetch(StatementHandle h, long offset, int fetchMaxRowCount) {
     final CalciteConnectionImpl calciteConnection = getConnection();
     CalciteServerStatement stmt = calciteConnection.server.getStatement(h);
     final Signature signature = stmt.getSignature();
     final Iterator<Object> iterator;
-    if (parameterValues != null) {
+    final boolean hasIterator = (stmt.getResultSet() == null) ? false : true;
+    if (!hasIterator) {
       final Iterable<Object> iterable =
-          createIterable(h, signature, parameterValues, null);
+          createIterable(h, signature, null, null);
       iterator = iterable.iterator();
       stmt.setResultSet(iterator);
     } else {
@@ -595,6 +595,38 @@ public class CalciteMetaImpl extends MetaImpl {
             LimitIterator.of(iterator, fetchMaxRowCount), list);
     boolean done = fetchMaxRowCount == 0 || list.size() < fetchMaxRowCount;
     return new Meta.Frame(offset, done, (List<Object>) (List) rows);
+  }
+
+  @Override public ExecuteResult execute(StatementHandle h,
+      List<TypedValue> parameterValues, long maxRowCount) {
+    final CalciteConnectionImpl calciteConnection = getConnection();
+    CalciteServerStatement stmt = calciteConnection.server.getStatement(h);
+    final Signature signature = stmt.getSignature();
+    final Iterator<Object> iterator;
+
+    final Iterable<Object> iterable =
+        createIterable(h, signature, parameterValues, null);
+    iterator = iterable.iterator();
+    stmt.setResultSet(iterator);
+
+    MetaResultSet metaResultSet;
+    if (signature.statementType.canUpdate()) {
+      metaResultSet = MetaResultSet.count(h.connectionId, h.id,
+          ((Number) iterator.next()).intValue());
+    } else {
+      final List<List<Object>> list = new ArrayList<>();
+      List<List<Object>> rows =
+          MetaImpl.collect(signature.cursorFactory,
+              LimitIterator.of(iterator, maxRowCount), list);
+      final boolean done = maxRowCount == 0 || list.size() < maxRowCount;
+      final Meta.Frame frame =
+          new Meta.Frame(0, done, (List<Object>) (List) rows);
+
+      metaResultSet =
+          MetaResultSet.create(h.connectionId, h.id, false, signature, frame);
+    }
+
+    return new ExecuteResult(ImmutableList.of(metaResultSet));
   }
 
   /** A trojan-horse method, subject to change without notice. */

--- a/core/src/main/java/org/apache/calcite/jdbc/CalcitePrepare.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalcitePrepare.java
@@ -297,7 +297,25 @@ public interface CalcitePrepare {
         List<ColumnMetaData> columns, Meta.CursorFactory cursorFactory,
         List<RelCollation> collationList, long maxRowCount,
         Bindable<T> bindable) {
-      super(columns, sql, parameterList, internalParameters, cursorFactory);
+      super(columns, sql, parameterList, internalParameters, cursorFactory, null);
+      this.rowType = rowType;
+      this.collationList = collationList;
+      this.maxRowCount = maxRowCount;
+      this.bindable = bindable;
+    }
+
+    public CalciteSignature(String sql,
+        List<AvaticaParameter> parameterList,
+        Map<String, Object> internalParameters,
+        RelDataType rowType,
+        List<ColumnMetaData> columns,
+        Meta.CursorFactory cursorFactory,
+        List<RelCollation> collationList,
+        long maxRowCount,
+        Bindable<T> bindable,
+        Meta.StatementType statementType) {
+      super(columns, sql, parameterList, internalParameters, cursorFactory,
+          statementType);
       this.rowType = rowType;
       this.collationList = collationList;
       this.maxRowCount = maxRowCount;

--- a/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
@@ -623,8 +623,36 @@ public class CalcitePrepareImpl implements CalcitePrepare {
           public Enumerable<T> bind(DataContext dataContext) {
             return Linq4j.asEnumerable(list);
           }
-        }
+        },
+        Meta.StatementType.SELECT
     );
+  }
+
+  /**
+   * Routine to figure out the StatementType and defaults to SELECT
+   * As CASE increases the default may change
+   * @param kind a SqlKind
+   * @return Meta.StatementType*/
+  private Meta.StatementType getStatementType(SqlKind kind) {
+    switch (kind) {
+    case INSERT:
+      return Meta.StatementType.INSERT;
+    default:
+      return Meta.StatementType.SELECT;
+    }
+  }
+
+  /**
+   * Routine to figure out the StatementType if call does not have sql
+   * defaults to SELECT
+   * @param preparedResult An objecet returned from prepareQueryable or prepareRel
+   * @return Meta.StatementType*/
+  private Meta.StatementType getStatementType(Prepare.PreparedResult preparedResult) {
+    if (preparedResult.isDml()) {
+      return Meta.StatementType.IS_DML;
+    } else {
+      return Meta.StatementType.SELECT;
+    }
   }
 
   <T> CalciteSignature<T> prepare2_(
@@ -650,6 +678,7 @@ public class CalcitePrepareImpl implements CalcitePrepare {
 
     final RelDataType x;
     final Prepare.PreparedResult preparedResult;
+    Meta.StatementType statementType = null;
     if (query.sql != null) {
       final CalciteConnectionConfig config = context.config();
       SqlParser parser = createParser(query.sql,
@@ -660,6 +689,7 @@ public class CalcitePrepareImpl implements CalcitePrepare {
       SqlNode sqlNode;
       try {
         sqlNode = parser.parseStmt();
+        statementType = getStatementType(sqlNode.getKind());
       } catch (SqlParseException e) {
         throw new RuntimeException(
             "parse failed: " + e.getMessage(), e);
@@ -715,10 +745,12 @@ public class CalcitePrepareImpl implements CalcitePrepare {
       x = context.getTypeFactory().createType(elementType);
       preparedResult =
           preparingStmt.prepareQueryable(query.queryable, x);
+      statementType = getStatementType(preparedResult);
     } else {
       assert query.rel != null;
       x = query.rel.getRowType();
       preparedResult = preparingStmt.prepareRel(query.rel);
+      statementType = getStatementType(preparedResult);
     }
 
     final List<AvaticaParameter> parameters = new ArrayList<>();
@@ -759,7 +791,8 @@ public class CalcitePrepareImpl implements CalcitePrepare {
             ? ((Prepare.PreparedResultImpl) preparedResult).collations
             : ImmutableList.<RelCollation>of(),
         maxRowCount,
-        bindable);
+        bindable,
+        statementType);
   }
 
   private List<ColumnMetaData> getColumnMetaDataList(


### PR DESCRIPTION
Merged with 046550e03dc49f4b748cace471fe64e49f8a6557

Updated implementation for LOCAL and REMOTE based on Julian's feedback

Rewired LocalService#toResponse because deprecated the use of list2

Add handle for signature.statementType == null

If signature is null then defaults to Meta.StatementType.SELECT

Add Meta import

Ignore Unit Test with DML that expects Result Set

Added testRemoteStatementInsert for JSON and PROTOBUF serialization test

Fixed various items related to ExecuteRequest + Fixed casting byte[] to ByteString + Added @Ignore to unit test that expected unbound parameter

Added IS_DML, to be consistent with Prepare.PreparedResult#isDml

Add routine to infer Meta.StatementType from Prepare.PrepareResult

Revert Ord

Add StatementHandle to CalciteConnection#server instance

Deprected FetchRequest#parameterValues and ignored FetchRequest parameter unit test

Resolved Protobuf parameterValues null element

Added FIXME to AbstractCursor#BinaryAccessor

Fixes for mvn site