### PR TITLE
[CALCITE-912] Add Avatica OpenConnectionRequest

### DIFF
--- a/avatica-server/pom.xml
+++ b/avatica-server/pom.xml
@@ -95,6 +95,11 @@ limitations under the License.
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.stephenc.jcip</groupId>
+      <artifactId>jcip-annotations</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/avatica-server/src/main/java/org/apache/calcite/avatica/jdbc/JdbcMeta.java
+++ b/avatica-server/src/main/java/org/apache/calcite/avatica/jdbc/JdbcMeta.java
@@ -75,7 +75,6 @@ public class JdbcMeta implements Meta {
 
   private final String url;
   private final Properties info;
-  private final Connection connection; // TODO: remove default connection
   private final Cache<String, Connection> connectionCache;
   private final Cache<Integer, StatementInfo> statementCache;
 
@@ -120,7 +119,6 @@ public class JdbcMeta implements Meta {
   public JdbcMeta(String url, Properties info) throws SQLException {
     this.url = url;
     this.info = info;
-    this.connection = DriverManager.getConnection(url, info);
 
     int concurrencyLevel = Integer.parseInt(
         info.getProperty(ConnectionCacheSettings.CONCURRENCY_LEVEL.key(),
@@ -236,10 +234,10 @@ public class JdbcMeta implements Meta {
     return signature(metaData, null, null);
   }
 
-  public Map<DatabaseProperty, Object> getDatabaseProperties() {
+  public Map<DatabaseProperty, Object> getDatabaseProperties(ConnectionHandle ch) {
     try {
       final Map<DatabaseProperty, Object> map = new HashMap<>();
-      final DatabaseMetaData metaData = connection.getMetaData();
+      final DatabaseMetaData metaData = getConnection(ch.id).getMetaData();
       for (DatabaseProperty p : DatabaseProperty.values()) {
         addProperty(map, metaData, p);
       }
@@ -258,11 +256,11 @@ public class JdbcMeta implements Meta {
     }
   }
 
-  public MetaResultSet getTables(String catalog, Pat schemaPattern,
+  public MetaResultSet getTables(ConnectionHandle ch, String catalog, Pat schemaPattern,
       Pat tableNamePattern, List<String> typeList) {
     try {
       final ResultSet rs =
-          connection.getMetaData().getTables(catalog, schemaPattern.s,
+          getConnection(ch.id).getMetaData().getTables(catalog, schemaPattern.s,
               tableNamePattern.s, toArray(typeList));
       return JdbcResultSet.create(DEFAULT_CONN_ID, -1, rs);
     } catch (SQLException e) {
@@ -270,11 +268,11 @@ public class JdbcMeta implements Meta {
     }
   }
 
-  public MetaResultSet getColumns(String catalog, Pat schemaPattern,
+  public MetaResultSet getColumns(ConnectionHandle ch, String catalog, Pat schemaPattern,
       Pat tableNamePattern, Pat columnNamePattern) {
     try {
       final ResultSet rs =
-          connection.getMetaData().getColumns(catalog, schemaPattern.s,
+          getConnection(ch.id).getMetaData().getColumns(catalog, schemaPattern.s,
               tableNamePattern.s, columnNamePattern.s);
       return JdbcResultSet.create(DEFAULT_CONN_ID, -1, rs);
     } catch (SQLException e) {
@@ -282,39 +280,39 @@ public class JdbcMeta implements Meta {
     }
   }
 
-  public MetaResultSet getSchemas(String catalog, Pat schemaPattern) {
+  public MetaResultSet getSchemas(ConnectionHandle ch, String catalog, Pat schemaPattern) {
     try {
       final ResultSet rs =
-          connection.getMetaData().getSchemas(catalog, schemaPattern.s);
+          getConnection(ch.id).getMetaData().getSchemas(catalog, schemaPattern.s);
       return JdbcResultSet.create(DEFAULT_CONN_ID, -1, rs);
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }
   }
 
-  public MetaResultSet getCatalogs() {
+  public MetaResultSet getCatalogs(ConnectionHandle ch) {
     try {
-      final ResultSet rs = connection.getMetaData().getCatalogs();
+      final ResultSet rs = getConnection(ch.id).getMetaData().getCatalogs();
       return JdbcResultSet.create(DEFAULT_CONN_ID, -1, rs);
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }
   }
 
-  public MetaResultSet getTableTypes() {
+  public MetaResultSet getTableTypes(ConnectionHandle ch) {
     try {
-      final ResultSet rs = connection.getMetaData().getTableTypes();
+      final ResultSet rs = getConnection(ch.id).getMetaData().getTableTypes();
       return JdbcResultSet.create(DEFAULT_CONN_ID, -1, rs);
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }
   }
 
-  public MetaResultSet getProcedures(String catalog, Pat schemaPattern,
+  public MetaResultSet getProcedures(ConnectionHandle ch, String catalog, Pat schemaPattern,
       Pat procedureNamePattern) {
     try {
       final ResultSet rs =
-          connection.getMetaData().getProcedures(catalog, schemaPattern.s,
+          getConnection(ch.id).getMetaData().getProcedures(catalog, schemaPattern.s,
               procedureNamePattern.s);
       return JdbcResultSet.create(DEFAULT_CONN_ID, -1, rs);
     } catch (SQLException e) {
@@ -322,11 +320,11 @@ public class JdbcMeta implements Meta {
     }
   }
 
-  public MetaResultSet getProcedureColumns(String catalog, Pat schemaPattern,
+  public MetaResultSet getProcedureColumns(ConnectionHandle ch, String catalog, Pat schemaPattern,
       Pat procedureNamePattern, Pat columnNamePattern) {
     try {
       final ResultSet rs =
-          connection.getMetaData().getProcedureColumns(catalog,
+          getConnection(ch.id).getMetaData().getProcedureColumns(catalog,
               schemaPattern.s, procedureNamePattern.s, columnNamePattern.s);
       return JdbcResultSet.create(DEFAULT_CONN_ID, -1, rs);
     } catch (SQLException e) {
@@ -334,11 +332,11 @@ public class JdbcMeta implements Meta {
     }
   }
 
-  public MetaResultSet getColumnPrivileges(String catalog, String schema,
+  public MetaResultSet getColumnPrivileges(ConnectionHandle ch, String catalog, String schema,
       String table, Pat columnNamePattern) {
     try {
       final ResultSet rs =
-          connection.getMetaData().getColumnPrivileges(catalog, schema,
+          getConnection(ch.id).getMetaData().getColumnPrivileges(catalog, schema,
               table, columnNamePattern.s);
       return JdbcResultSet.create(DEFAULT_CONN_ID, -1, rs);
     } catch (SQLException e) {
@@ -346,11 +344,11 @@ public class JdbcMeta implements Meta {
     }
   }
 
-  public MetaResultSet getTablePrivileges(String catalog, Pat schemaPattern,
+  public MetaResultSet getTablePrivileges(ConnectionHandle ch, String catalog, Pat schemaPattern,
       Pat tableNamePattern) {
     try {
       final ResultSet rs =
-          connection.getMetaData().getTablePrivileges(catalog,
+          getConnection(ch.id).getMetaData().getTablePrivileges(catalog,
               schemaPattern.s, tableNamePattern.s);
       return JdbcResultSet.create(DEFAULT_CONN_ID, -1, rs);
     } catch (SQLException e) {
@@ -358,7 +356,7 @@ public class JdbcMeta implements Meta {
     }
   }
 
-  public MetaResultSet getBestRowIdentifier(String catalog, String schema,
+  public MetaResultSet getBestRowIdentifier(ConnectionHandle ch, String catalog, String schema,
       String table, int scope, boolean nullable) {
     if (LOG.isTraceEnabled()) {
       LOG.trace("getBestRowIdentifier catalog:" + catalog + " schema:" + schema
@@ -366,7 +364,7 @@ public class JdbcMeta implements Meta {
     }
     try {
       final ResultSet rs =
-          connection.getMetaData().getBestRowIdentifier(catalog, schema,
+          getConnection(ch.id).getMetaData().getBestRowIdentifier(catalog, schema,
               table, scope, nullable);
       return JdbcResultSet.create(DEFAULT_CONN_ID, -1, rs);
     } catch (SQLException e) {
@@ -374,99 +372,99 @@ public class JdbcMeta implements Meta {
     }
   }
 
-  public MetaResultSet getVersionColumns(String catalog, String schema,
+  public MetaResultSet getVersionColumns(ConnectionHandle ch, String catalog, String schema,
       String table) {
     if (LOG.isTraceEnabled()) {
       LOG.trace("getVersionColumns catalog:" + catalog + " schema:" + schema + " table:" + table);
     }
     try {
       final ResultSet rs =
-          connection.getMetaData().getVersionColumns(catalog, schema, table);
+          getConnection(ch.id).getMetaData().getVersionColumns(catalog, schema, table);
       return JdbcResultSet.create(DEFAULT_CONN_ID, -1, rs);
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }
   }
 
-  public MetaResultSet getPrimaryKeys(String catalog, String schema,
+  public MetaResultSet getPrimaryKeys(ConnectionHandle ch, String catalog, String schema,
       String table) {
     if (LOG.isTraceEnabled()) {
       LOG.trace("getPrimaryKeys catalog:" + catalog + " schema:" + schema + " table:" + table);
     }
     try {
       final ResultSet rs =
-          connection.getMetaData().getPrimaryKeys(catalog, schema, table);
+          getConnection(ch.id).getMetaData().getPrimaryKeys(catalog, schema, table);
       return JdbcResultSet.create(DEFAULT_CONN_ID, -1, rs);
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }
   }
 
-  public MetaResultSet getImportedKeys(String catalog, String schema,
+  public MetaResultSet getImportedKeys(ConnectionHandle ch, String catalog, String schema,
       String table) {
     return null;
   }
 
-  public MetaResultSet getExportedKeys(String catalog, String schema,
+  public MetaResultSet getExportedKeys(ConnectionHandle ch, String catalog, String schema,
       String table) {
     return null;
   }
 
-  public MetaResultSet getCrossReference(String parentCatalog,
+  public MetaResultSet getCrossReference(ConnectionHandle ch, String parentCatalog,
       String parentSchema, String parentTable, String foreignCatalog,
       String foreignSchema, String foreignTable) {
     return null;
   }
 
-  public MetaResultSet getTypeInfo() {
+  public MetaResultSet getTypeInfo(ConnectionHandle ch) {
     try {
-      final ResultSet rs = connection.getMetaData().getTypeInfo();
+      final ResultSet rs = getConnection(ch.id).getMetaData().getTypeInfo();
       return JdbcResultSet.create(DEFAULT_CONN_ID, -1, rs);
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }
   }
 
-  public MetaResultSet getIndexInfo(String catalog, String schema, String table,
-      boolean unique, boolean approximate) {
+  public MetaResultSet getIndexInfo(ConnectionHandle ch, String catalog, String schema,
+      String table, boolean unique, boolean approximate) {
     return null;
   }
 
-  public MetaResultSet getUDTs(String catalog, Pat schemaPattern,
+  public MetaResultSet getUDTs(ConnectionHandle ch, String catalog, Pat schemaPattern,
       Pat typeNamePattern, int[] types) {
     return null;
   }
 
-  public MetaResultSet getSuperTypes(String catalog, Pat schemaPattern,
+  public MetaResultSet getSuperTypes(ConnectionHandle ch, String catalog, Pat schemaPattern,
       Pat typeNamePattern) {
     return null;
   }
 
-  public MetaResultSet getSuperTables(String catalog, Pat schemaPattern,
+  public MetaResultSet getSuperTables(ConnectionHandle ch, String catalog, Pat schemaPattern,
       Pat tableNamePattern) {
     return null;
   }
 
-  public MetaResultSet getAttributes(String catalog, Pat schemaPattern,
+  public MetaResultSet getAttributes(ConnectionHandle ch, String catalog, Pat schemaPattern,
       Pat typeNamePattern, Pat attributeNamePattern) {
     return null;
   }
 
-  public MetaResultSet getClientInfoProperties() {
+  public MetaResultSet getClientInfoProperties(ConnectionHandle ch) {
     return null;
   }
 
-  public MetaResultSet getFunctions(String catalog, Pat schemaPattern,
+  public MetaResultSet getFunctions(ConnectionHandle ch, String catalog, Pat schemaPattern,
       Pat functionNamePattern) {
     return null;
   }
 
-  public MetaResultSet getFunctionColumns(String catalog, Pat schemaPattern,
+  public MetaResultSet getFunctionColumns(ConnectionHandle ch, String catalog, Pat schemaPattern,
       Pat functionNamePattern, Pat columnNamePattern) {
     return null;
   }
 
-  public MetaResultSet getPseudoColumns(String catalog, Pat schemaPattern,
+  public MetaResultSet getPseudoColumns(ConnectionHandle ch, String catalog, Pat schemaPattern,
       Pat tableNamePattern, Pat columnNamePattern) {
     return null;
   }
@@ -477,10 +475,12 @@ public class JdbcMeta implements Meta {
   }
 
   protected Connection getConnection(String id) throws SQLException {
+    if (id == null) {
+      throw new NullPointerException("Connection id is null.");
+    }
     Connection conn = connectionCache.getIfPresent(id);
     if (conn == null) {
-      conn = DriverManager.getConnection(url, info);
-      connectionCache.put(id, conn);
+      throw new RuntimeException("Connection not found: invalid id, closed, or expired: " + id);
     }
     return conn;
   }
@@ -519,6 +519,27 @@ public class JdbcMeta implements Meta {
       throw propagate(e);
     } finally {
       statementCache.invalidate(h.id);
+    }
+  }
+
+  @Override
+  public void openConnection(ConnectionHandle ch, Map<String, String> info) {
+    Properties fullInfo = new Properties();
+    fullInfo.putAll(this.info);
+    if (info != null) {
+      fullInfo.putAll(info);
+    }
+
+    synchronized (this) {
+      try {
+        if (connectionCache.asMap().containsKey(ch.id)) {
+          throw new RuntimeException("Connection already exists: " + ch.id);
+        }
+        Connection conn = DriverManager.getConnection(url, fullInfo);
+        connectionCache.put(ch.id, conn);
+      } catch (SQLException e) {
+        throw new RuntimeException(e);
+      }
     }
   }
 
@@ -783,10 +804,6 @@ public class JdbcMeta implements Meta {
     public void onRemoval(RemovalNotification<String, Connection> notification) {
       String connectionId = notification.getKey();
       Connection doomed = notification.getValue();
-      // is String.equals() more efficient?
-      if (notification.getValue() == connection) {
-        return;
-      }
       if (LOG.isDebugEnabled()) {
         LOG.debug("Expiring connection " + connectionId + " because "
                 + notification.getCause());

--- a/avatica-server/src/test/java/org/apache/calcite/avatica/RemoteDriverMockTest.java
+++ b/avatica-server/src/test/java/org/apache/calcite/avatica/RemoteDriverMockTest.java
@@ -94,8 +94,7 @@ public class RemoteDriverMockTest {
   }
 
   @Test public void testRegister() throws Exception {
-    final Connection connection =
-        DriverManager.getConnection("jdbc:avatica:remote:");
+    final Connection connection = getMockConnection();
     assertThat(connection.isClosed(), is(false));
     connection.close();
     assertThat(connection.isClosed(), is(true));

--- a/avatica-server/src/test/java/org/apache/calcite/avatica/RemoteDriverTest.java
+++ b/avatica-server/src/test/java/org/apache/calcite/avatica/RemoteDriverTest.java
@@ -27,6 +27,8 @@ import org.apache.calcite.avatica.remote.Service;
 
 import com.google.common.cache.Cache;
 
+import net.jcip.annotations.NotThreadSafe;
+
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -68,6 +70,7 @@ import static org.junit.Assert.fail;
  * Unit test for Avatica Remote JDBC driver.
  */
 @RunWith(Parameterized.class)
+@NotThreadSafe // for testConnectionIsolation
 public class RemoteDriverTest {
   public static final String LJS =
       LocalJdbcServiceFactory.class.getName();
@@ -213,8 +216,7 @@ public class RemoteDriverTest {
   }
 
   @Test public void testRegister() throws Exception {
-    final Connection connection =
-        DriverManager.getConnection("jdbc:avatica:remote:");
+    final Connection connection = getLocalConnection();
     assertThat(connection.isClosed(), is(false));
     connection.close();
     assertThat(connection.isClosed(), is(true));
@@ -753,23 +755,26 @@ public class RemoteDriverTest {
   @Test public void testConnectionIsolation() throws Exception {
     ConnectionSpec.getDatabaseLock().lock();
     try {
-      final String sql = "select * from (values (1, 'a'))";
-      Connection conn1 = getLocalConnection();
-      Connection conn2 = getLocalConnection();
       Cache<String, Connection> connectionMap = getLocalConnectionInternals()
-          .getRemoteConnectionMap((AvaticaConnection) conn1);
+          .getRemoteConnectionMap((AvaticaConnection) getLocalConnection());
       // Other tests being run might leave connections in the cache.
       // The lock guards against more connections being cached during the test.
       connectionMap.invalidateAll();
+
+      final String sql = "select * from (values (1, 'a'))";
       assertEquals("connection cache should start empty",
           0, connectionMap.size());
+      Connection conn1 = getLocalConnection();
+      Connection conn2 = getLocalConnection();
+      assertEquals("we now have two connections open",
+          2, connectionMap.size());
       PreparedStatement conn1stmt1 = conn1.prepareStatement(sql);
       assertEquals(
-          "statement creation implicitly creates a connection server-side",
-          1, connectionMap.size());
+          "creating a statement does not cause new connection",
+          2, connectionMap.size());
       PreparedStatement conn2stmt1 = conn2.prepareStatement(sql);
       assertEquals(
-          "statement creation implicitly creates a connection server-side",
+          "creating a statement does not cause new connection",
           2, connectionMap.size());
       AvaticaPreparedStatement s1 = (AvaticaPreparedStatement) conn1stmt1;
       AvaticaPreparedStatement s2 = (AvaticaPreparedStatement) conn2stmt1;

--- a/avatica-server/src/test/java/org/apache/calcite/avatica/remote/RemoteMetaTest.java
+++ b/avatica-server/src/test/java/org/apache/calcite/avatica/remote/RemoteMetaTest.java
@@ -48,11 +48,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /** Tests covering {@link RemoteMeta}. */
 @RunWith(Parameterized.class)
@@ -257,6 +259,60 @@ public class RemoteMetaTest {
       }
     } finally {
       ConnectionSpec.getDatabaseLock().unlock();
+    }
+  }
+
+  @Test public void testOpenConnectionWithProperties() throws Exception {
+    // This tests that username and password are used for creating a connection on the
+    // server. If this was not the case, it would succeed.
+    try {
+      DriverManager.getConnection(url, "john", "doe");
+      fail("expected exception");
+    } catch (RuntimeException e) {
+      assertEquals("Remote driver error:"
+          + " java.sql.SQLInvalidAuthorizationSpecException: invalid authorization specification"
+          + " - not found: john"
+          + " -> invalid authorization specification - not found: john"
+          + " -> invalid authorization specification - not found: john",
+          e.getMessage());
+    }
+  }
+
+  @Test public void testRemoteConnectionsAreDifferent() throws SQLException {
+    Connection conn1 = DriverManager.getConnection(url);
+    Statement stmt = conn1.createStatement();
+    stmt.execute("DECLARE LOCAL TEMPORARY TABLE"
+        + " buffer (id INTEGER PRIMARY KEY, textdata VARCHAR(100))");
+    stmt.execute("insert into buffer(id, textdata) values(1, 'abc')");
+    stmt.executeQuery("select * from buffer");
+
+    // The local temporary table is local to the connection above, and should
+    // not be visible on another connection
+    Connection conn2 = DriverManager.getConnection(url);
+    Statement stmt2 = conn2.createStatement();
+    try {
+      stmt2.executeQuery("select * from buffer");
+      fail("expected exception");
+    } catch (Exception e) {
+      assertEquals("Remote driver error: java.sql.SQLSyntaxErrorException: user lacks privilege"
+          + " or object not found: BUFFER -> user lacks privilege or object not found: BUFFER"
+          + " -> user lacks privilege or object not found: BUFFER", e.getCause().getMessage());
+    }
+  }
+
+  @Test public void testRemoteConnectionClosing() throws Exception {
+    AvaticaConnection conn = (AvaticaConnection) DriverManager.getConnection(url);
+    // Verify connection is usable
+    conn.createStatement();
+    conn.close();
+
+    // After closing the connection, it should not be usable anymore
+    try {
+      conn.createStatement();
+      fail("expected exception");
+    } catch (RuntimeException e) {
+      assertThat(e.getMessage(), containsString("Remote driver error:"
+          + " Connection not found: invalid id, closed, or expired"));
     }
   }
 }

--- a/avatica/src/main/java/org/apache/calcite/avatica/AvaticaConnection.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/AvaticaConnection.java
@@ -273,8 +273,7 @@ public abstract class AvaticaConnection implements Connection {
       int resultSetConcurrency,
       int resultSetHoldability) throws SQLException {
     try {
-      final Meta.ConnectionHandle ch = new Meta.ConnectionHandle(id);
-      final Meta.StatementHandle h = meta.prepare(ch, sql, -1);
+      final Meta.StatementHandle h = meta.prepare(handle, sql, -1);
       return factory.newPreparedStatement(this, h, h.signature, resultSetType,
           resultSetConcurrency, resultSetHoldability);
     } catch (RuntimeException e) {

--- a/avatica/src/main/java/org/apache/calcite/avatica/AvaticaDatabaseMetaData.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/AvaticaDatabaseMetaData.java
@@ -183,27 +183,27 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
 
   public String getSQLKeywords() throws SQLException {
     return Meta.DatabaseProperty.GET_S_Q_L_KEYWORDS
-        .getProp(connection.meta, String.class);
+        .getProp(connection.meta, connection.handle, String.class);
   }
 
   public String getNumericFunctions() throws SQLException {
     return Meta.DatabaseProperty.GET_NUMERIC_FUNCTIONS
-        .getProp(connection.meta, String.class);
+        .getProp(connection.meta, connection.handle, String.class);
   }
 
   public String getStringFunctions() throws SQLException {
     return Meta.DatabaseProperty.GET_STRING_FUNCTIONS
-        .getProp(connection.meta, String.class);
+        .getProp(connection.meta, connection.handle, String.class);
   }
 
   public String getSystemFunctions() throws SQLException {
     return Meta.DatabaseProperty.GET_SYSTEM_FUNCTIONS
-        .getProp(connection.meta, String.class);
+        .getProp(connection.meta, connection.handle, String.class);
   }
 
   public String getTimeDateFunctions() throws SQLException {
     return Meta.DatabaseProperty.GET_TIME_DATE_FUNCTIONS
-        .getProp(connection.meta, String.class);
+        .getProp(connection.meta, connection.handle, String.class);
   }
 
   public String getSearchStringEscape() throws SQLException {
@@ -529,7 +529,7 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
 
   public int getDefaultTransactionIsolation() throws SQLException {
     return Meta.DatabaseProperty.GET_DEFAULT_TRANSACTION_ISOLATION
-        .getProp(connection.meta, Integer.class);
+        .getProp(connection.meta, connection.handle, Integer.class);
   }
 
   public boolean supportsTransactions() throws SQLException {
@@ -564,7 +564,7 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
       String schemaPattern,
       String procedureNamePattern) throws SQLException {
     return connection.createResultSet(
-        connection.meta.getProcedures(catalog, pat(schemaPattern),
+        connection.meta.getProcedures(connection.handle, catalog, pat(schemaPattern),
             pat(procedureNamePattern)));
   }
 
@@ -574,7 +574,7 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
       String procedureNamePattern,
       String columnNamePattern) throws SQLException {
     return connection.createResultSet(
-        connection.meta.getProcedureColumns(catalog, pat(schemaPattern),
+        connection.meta.getProcedureColumns(connection.handle, catalog, pat(schemaPattern),
             pat(procedureNamePattern), pat(columnNamePattern)));
   }
 
@@ -585,7 +585,7 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
       String[] types) throws SQLException {
     List<String> typeList = types == null ? null : Arrays.asList(types);
     return connection.createResultSet(
-        connection.meta.getTables(catalog, pat(schemaPattern),
+        connection.meta.getTables(connection.handle, catalog, pat(schemaPattern),
             pat(tableNamePattern), typeList));
   }
 
@@ -598,7 +598,7 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
     // TODO: add a 'catch ... throw new SQLException' logic to this and other
     // getXxx methods. Right now any error will throw a RuntimeException
     return connection.createResultSet(
-        connection.meta.getSchemas(catalog, pat(schemaPattern)));
+        connection.meta.getSchemas(connection.handle, catalog, pat(schemaPattern)));
   }
 
   public ResultSet getSchemas() throws SQLException {
@@ -606,11 +606,11 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
   }
 
   public ResultSet getCatalogs() throws SQLException {
-    return connection.createResultSet(connection.meta.getCatalogs());
+    return connection.createResultSet(connection.meta.getCatalogs(connection.handle));
   }
 
   public ResultSet getTableTypes() throws SQLException {
-    return connection.createResultSet(connection.meta.getTableTypes());
+    return connection.createResultSet(connection.meta.getTableTypes(connection.handle));
   }
 
   public ResultSet getColumns(
@@ -619,7 +619,8 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
       String tableNamePattern,
       String columnNamePattern) throws SQLException {
     return connection.createResultSet(
-        connection.meta.getColumns(catalog, pat(schemaPattern),
+        connection.meta.getColumns(connection.handle,
+            catalog, pat(schemaPattern),
             pat(tableNamePattern), pat(columnNamePattern)));
   }
 
@@ -629,7 +630,7 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
       String table,
       String columnNamePattern) throws SQLException {
     return connection.createResultSet(
-        connection.meta.getColumnPrivileges(catalog, schema, table,
+        connection.meta.getColumnPrivileges(connection.handle, catalog, schema, table,
             pat(columnNamePattern)));
   }
 
@@ -638,7 +639,7 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
       String schemaPattern,
       String tableNamePattern) throws SQLException {
     return connection.createResultSet(
-        connection.meta.getTablePrivileges(catalog, pat(schemaPattern),
+        connection.meta.getTablePrivileges(connection.handle, catalog, pat(schemaPattern),
             pat(tableNamePattern)));
   }
 
@@ -649,32 +650,32 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
       int scope,
       boolean nullable) throws SQLException {
     return connection.createResultSet(
-        connection.meta.getBestRowIdentifier(catalog, schema, table, scope,
+        connection.meta.getBestRowIdentifier(connection.handle, catalog, schema, table, scope,
             nullable));
   }
 
   public ResultSet getVersionColumns(
       String catalog, String schema, String table) throws SQLException {
     return connection.createResultSet(
-        connection.meta.getVersionColumns(catalog, schema, table));
+        connection.meta.getVersionColumns(connection.handle, catalog, schema, table));
   }
 
   public ResultSet getPrimaryKeys(
       String catalog, String schema, String table) throws SQLException {
     return connection.createResultSet(
-        connection.meta.getPrimaryKeys(catalog, schema, table));
+        connection.meta.getPrimaryKeys(connection.handle, catalog, schema, table));
   }
 
   public ResultSet getImportedKeys(
       String catalog, String schema, String table) throws SQLException {
     return connection.createResultSet(
-        connection.meta.getImportedKeys(catalog, schema, table));
+        connection.meta.getImportedKeys(connection.handle, catalog, schema, table));
   }
 
   public ResultSet getExportedKeys(
       String catalog, String schema, String table) throws SQLException {
     return connection.createResultSet(
-        connection.meta.getExportedKeys(catalog, schema, table));
+        connection.meta.getExportedKeys(connection.handle, catalog, schema, table));
   }
 
   public ResultSet getCrossReference(
@@ -685,12 +686,12 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
       String foreignSchema,
       String foreignTable) throws SQLException {
     return connection.createResultSet(
-        connection.meta.getCrossReference(parentCatalog, parentSchema,
+        connection.meta.getCrossReference(connection.handle, parentCatalog, parentSchema,
             parentTable, foreignCatalog, foreignSchema, foreignTable));
   }
 
   public ResultSet getTypeInfo() throws SQLException {
-    return connection.createResultSet(connection.meta.getTypeInfo());
+    return connection.createResultSet(connection.meta.getTypeInfo(connection.handle));
   }
 
   public ResultSet getIndexInfo(
@@ -700,7 +701,7 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
       boolean unique,
       boolean approximate) throws SQLException {
     return connection.createResultSet(
-        connection.meta.getIndexInfo(catalog, schema, table, unique,
+        connection.meta.getIndexInfo(connection.handle, catalog, schema, table, unique,
             approximate));
   }
 
@@ -760,7 +761,7 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
       String typeNamePattern,
       int[] types) throws SQLException {
     return connection.createResultSet(
-        connection.meta.getUDTs(catalog, pat(schemaPattern),
+        connection.meta.getUDTs(connection.handle, catalog, pat(schemaPattern),
             pat(typeNamePattern), types));
   }
 
@@ -789,7 +790,7 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
       String schemaPattern,
       String typeNamePattern) throws SQLException {
     return connection.createResultSet(
-        connection.meta.getSuperTypes(catalog, pat(schemaPattern),
+        connection.meta.getSuperTypes(connection.handle, catalog, pat(schemaPattern),
             pat(typeNamePattern)));
   }
 
@@ -798,7 +799,7 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
       String schemaPattern,
       String tableNamePattern) throws SQLException {
     return connection.createResultSet(
-        connection.meta.getSuperTables(catalog, pat(schemaPattern),
+        connection.meta.getSuperTables(connection.handle, catalog, pat(schemaPattern),
             pat(tableNamePattern)));
   }
 
@@ -808,7 +809,7 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
       String typeNamePattern,
       String attributeNamePattern) throws SQLException {
     return connection.createResultSet(
-        connection.meta.getAttributes(catalog, pat(schemaPattern),
+        connection.meta.getAttributes(connection.handle, catalog, pat(schemaPattern),
             pat(typeNamePattern), pat(attributeNamePattern)));
   }
 
@@ -864,7 +865,7 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
 
   public ResultSet getClientInfoProperties() throws SQLException {
     return connection.createResultSet(
-        connection.meta.getClientInfoProperties());
+        connection.meta.getClientInfoProperties(connection.handle));
   }
 
   public ResultSet getFunctions(
@@ -872,7 +873,7 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
       String schemaPattern,
       String functionNamePattern) throws SQLException {
     return connection.createResultSet(
-        connection.meta.getFunctions(catalog, pat(schemaPattern),
+        connection.meta.getFunctions(connection.handle, catalog, pat(schemaPattern),
             pat(functionNamePattern)));
   }
 
@@ -882,7 +883,7 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
       String functionNamePattern,
       String columnNamePattern) throws SQLException {
     return connection.createResultSet(
-        connection.meta.getFunctionColumns(catalog, pat(schemaPattern),
+        connection.meta.getFunctionColumns(connection.handle, catalog, pat(schemaPattern),
             pat(functionNamePattern), pat(columnNamePattern)));
   }
 
@@ -892,7 +893,7 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
       String tableNamePattern,
       String columnNamePattern) throws SQLException {
     return connection.createResultSet(
-        connection.meta.getPseudoColumns(catalog, pat(schemaPattern),
+        connection.meta.getPseudoColumns(connection.handle, catalog, pat(schemaPattern),
             pat(tableNamePattern), pat(columnNamePattern)));
   }
 

--- a/avatica/src/main/java/org/apache/calcite/avatica/Meta.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/Meta.java
@@ -58,73 +58,81 @@ public interface Meta {
    * <p>The provider can omit properties whose value is the same as the
    * default.
    */
-  Map<DatabaseProperty, Object> getDatabaseProperties();
+  Map<DatabaseProperty, Object> getDatabaseProperties(ConnectionHandle ch);
 
   /** Per {@link DatabaseMetaData#getTables(String, String, String, String[])}. */
-  MetaResultSet getTables(String catalog,
+  MetaResultSet getTables(ConnectionHandle ch,
+      String catalog,
       Pat schemaPattern,
       Pat tableNamePattern,
       List<String> typeList);
 
   /** Per {@link DatabaseMetaData#getColumns(String, String, String, String)}. */
-  MetaResultSet getColumns(String catalog,
+  MetaResultSet getColumns(ConnectionHandle ch,
+      String catalog,
       Pat schemaPattern,
       Pat tableNamePattern,
       Pat columnNamePattern);
 
-  MetaResultSet getSchemas(String catalog, Pat schemaPattern);
+  MetaResultSet getSchemas(ConnectionHandle ch, String catalog, Pat schemaPattern);
 
   /** Per {@link DatabaseMetaData#getCatalogs()}. */
-  MetaResultSet getCatalogs();
+  MetaResultSet getCatalogs(ConnectionHandle ch);
 
   /** Per {@link DatabaseMetaData#getTableTypes()}. */
-  MetaResultSet getTableTypes();
+  MetaResultSet getTableTypes(ConnectionHandle ch);
 
   /** Per {@link DatabaseMetaData#getProcedures(String, String, String)}. */
-  MetaResultSet getProcedures(String catalog,
+  MetaResultSet getProcedures(ConnectionHandle ch,
+      String catalog,
       Pat schemaPattern,
       Pat procedureNamePattern);
 
   /** Per {@link DatabaseMetaData#getProcedureColumns(String, String, String, String)}. */
-  MetaResultSet getProcedureColumns(String catalog,
+  MetaResultSet getProcedureColumns(ConnectionHandle ch,
+      String catalog,
       Pat schemaPattern,
       Pat procedureNamePattern,
       Pat columnNamePattern);
 
   /** Per {@link DatabaseMetaData#getColumnPrivileges(String, String, String, String)}. */
-  MetaResultSet getColumnPrivileges(String catalog,
+  MetaResultSet getColumnPrivileges(ConnectionHandle ch,
+      String catalog,
       String schema,
       String table,
       Pat columnNamePattern);
 
   /** Per {@link DatabaseMetaData#getTablePrivileges(String, String, String)}. */
-  MetaResultSet getTablePrivileges(String catalog,
+  MetaResultSet getTablePrivileges(ConnectionHandle ch,
+      String catalog,
       Pat schemaPattern,
       Pat tableNamePattern);
 
   /** Per
    * {@link DatabaseMetaData#getBestRowIdentifier(String, String, String, int, boolean)}. */
-  MetaResultSet getBestRowIdentifier(String catalog,
+  MetaResultSet getBestRowIdentifier(ConnectionHandle ch,
+      String catalog,
       String schema,
       String table,
       int scope,
       boolean nullable);
 
   /** Per {@link DatabaseMetaData#getVersionColumns(String, String, String)}. */
-  MetaResultSet getVersionColumns(String catalog, String schema, String table);
+  MetaResultSet getVersionColumns(ConnectionHandle ch, String catalog, String schema, String table);
 
   /** Per {@link DatabaseMetaData#getPrimaryKeys(String, String, String)}. */
-  MetaResultSet getPrimaryKeys(String catalog, String schema, String table);
+  MetaResultSet getPrimaryKeys(ConnectionHandle ch, String catalog, String schema, String table);
 
   /** Per {@link DatabaseMetaData#getImportedKeys(String, String, String)}. */
-  MetaResultSet getImportedKeys(String catalog, String schema, String table);
+  MetaResultSet getImportedKeys(ConnectionHandle ch, String catalog, String schema, String table);
 
   /** Per {@link DatabaseMetaData#getExportedKeys(String, String, String)}. */
-  MetaResultSet getExportedKeys(String catalog, String schema, String table);
+  MetaResultSet getExportedKeys(ConnectionHandle ch, String catalog, String schema, String table);
 
   /** Per
    * {@link DatabaseMetaData#getCrossReference(String, String, String, String, String, String)}. */
-  MetaResultSet getCrossReference(String parentCatalog,
+  MetaResultSet getCrossReference(ConnectionHandle ch,
+      String parentCatalog,
       String parentSchema,
       String parentTable,
       String foreignCatalog,
@@ -132,53 +140,60 @@ public interface Meta {
       String foreignTable);
 
   /** Per {@link DatabaseMetaData#getTypeInfo()}. */
-  MetaResultSet getTypeInfo();
+  MetaResultSet getTypeInfo(ConnectionHandle ch);
 
   /** Per {@link DatabaseMetaData#getIndexInfo(String, String, String, boolean, boolean)}. */
-  MetaResultSet getIndexInfo(String catalog,
+  MetaResultSet getIndexInfo(ConnectionHandle ch, String catalog,
       String schema,
       String table,
       boolean unique,
       boolean approximate);
 
   /** Per {@link DatabaseMetaData#getUDTs(String, String, String, int[])}. */
-  MetaResultSet getUDTs(String catalog,
+  MetaResultSet getUDTs(ConnectionHandle ch,
+      String catalog,
       Pat schemaPattern,
       Pat typeNamePattern,
       int[] types);
 
   /** Per {@link DatabaseMetaData#getSuperTypes(String, String, String)}. */
-  MetaResultSet getSuperTypes(String catalog,
+  MetaResultSet getSuperTypes(ConnectionHandle ch,
+      String catalog,
       Pat schemaPattern,
       Pat typeNamePattern);
 
   /** Per {@link DatabaseMetaData#getSuperTables(String, String, String)}. */
-  MetaResultSet getSuperTables(String catalog,
+  MetaResultSet getSuperTables(ConnectionHandle ch,
+      String catalog,
       Pat schemaPattern,
       Pat tableNamePattern);
 
   /** Per {@link DatabaseMetaData#getAttributes(String, String, String, String)}. */
-  MetaResultSet getAttributes(String catalog,
+  MetaResultSet getAttributes(ConnectionHandle ch,
+      String catalog,
       Pat schemaPattern,
       Pat typeNamePattern,
       Pat attributeNamePattern);
 
   /** Per {@link DatabaseMetaData#getClientInfoProperties()}. */
-  MetaResultSet getClientInfoProperties();
+  MetaResultSet getClientInfoProperties(ConnectionHandle ch);
 
   /** Per {@link DatabaseMetaData#getFunctions(String, String, String)}. */
-  MetaResultSet getFunctions(String catalog,
+  MetaResultSet getFunctions(ConnectionHandle ch,
+      String catalog,
       Pat schemaPattern,
       Pat functionNamePattern);
 
   /** Per {@link DatabaseMetaData#getFunctionColumns(String, String, String, String)}. */
-  MetaResultSet getFunctionColumns(String catalog,
+  MetaResultSet getFunctionColumns(ConnectionHandle ch,
+      String catalog,
       Pat schemaPattern,
       Pat functionNamePattern,
       Pat columnNamePattern);
 
   /** Per {@link DatabaseMetaData#getPseudoColumns(String, String, String, String)}. */
-  MetaResultSet getPseudoColumns(String catalog,
+  MetaResultSet getPseudoColumns(ConnectionHandle ch,
+      String catalog,
       Pat schemaPattern,
       Pat tableNamePattern,
       Pat columnNamePattern);
@@ -242,6 +257,9 @@ public interface Meta {
    */
   void closeStatement(StatementHandle h);
 
+  /** Open (create) a connection */
+  void openConnection(ConnectionHandle ch, Map<String, String> info);
+
   /** Close a connection */
   void closeConnection(ConnectionHandle ch);
 
@@ -284,7 +302,7 @@ public interface Meta {
    * {@link DatabaseMetaData#getSQLKeywords()}, which always return the same
    * value at all times and across connections.
    *
-   * @see #getDatabaseProperties()
+   * @see #getDatabaseProperties(Meta.ConnectionHandle)
    */
   enum DatabaseProperty {
     /** Database property containing the value of
@@ -329,8 +347,8 @@ public interface Meta {
 
     /** Returns a value of this property, using the default value if the map
      * does not contain an explicit value. */
-    public <T> T getProp(Meta meta, Class<T> aClass) {
-      return getProp(meta.getDatabaseProperties(), aClass);
+    public <T> T getProp(Meta meta, ConnectionHandle ch, Class<T> aClass) {
+      return getProp(meta.getDatabaseProperties(ch), aClass);
     }
 
     /** Returns a value of this property, using the default value if the map

--- a/avatica/src/main/java/org/apache/calcite/avatica/MetaImpl.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/MetaImpl.java
@@ -48,7 +48,7 @@ import java.util.NoSuchElementException;
  * <p>Each sub-class must implement the two remaining abstract methods,
  * {@link #prepare} and
  * {@link #prepareAndExecute}.
- * It should also override metadata methods such as {@link #getCatalogs()} and
+ * It should also override metadata methods such as {@link #getCatalogs(Meta.ConnectionHandle)} and
  * {@link #getTables} for the element types for which it has instances; the
  * default metadata methods return empty collections.
  */
@@ -178,6 +178,10 @@ public abstract class MetaImpl implements Meta {
     default:
       throw new AssertionError("unknown style: " + cursorFactory.style);
     }
+  }
+
+  @Override public void openConnection(ConnectionHandle ch, Map<String, String> info) {
+    // dummy implementation, connection is already created at this point
   }
 
   @Override public void closeConnection(ConnectionHandle ch) {
@@ -569,63 +573,69 @@ public abstract class MetaImpl implements Meta {
   public static class MetaSuperTable {
   }
 
-  public Map<DatabaseProperty, Object> getDatabaseProperties() {
+  public Map<DatabaseProperty, Object> getDatabaseProperties(ConnectionHandle ch) {
     return Collections.emptyMap();
   }
 
-  public MetaResultSet getTables(String catalog,
+  public MetaResultSet getTables(ConnectionHandle ch,
+      String catalog,
       Pat schemaPattern,
       Pat tableNamePattern,
       List<String> typeList) {
     return createEmptyResultSet(MetaTable.class);
   }
 
-  public MetaResultSet getColumns(String catalog,
+  public MetaResultSet getColumns(ConnectionHandle ch, String catalog,
       Pat schemaPattern,
       Pat tableNamePattern,
       Pat columnNamePattern) {
     return createEmptyResultSet(MetaColumn.class);
   }
 
-  public MetaResultSet getSchemas(String catalog, Pat schemaPattern) {
+  public MetaResultSet getSchemas(ConnectionHandle ch, String catalog, Pat schemaPattern) {
     return createEmptyResultSet(MetaSchema.class);
   }
 
-  public MetaResultSet getCatalogs() {
+  public MetaResultSet getCatalogs(ConnectionHandle ch) {
     return createEmptyResultSet(MetaCatalog.class);
   }
 
-  public MetaResultSet getTableTypes() {
+  public MetaResultSet getTableTypes(ConnectionHandle ch) {
     return createEmptyResultSet(MetaTableType.class);
   }
 
-  public MetaResultSet getProcedures(String catalog,
+  public MetaResultSet getProcedures(ConnectionHandle ch,
+      String catalog,
       Pat schemaPattern,
       Pat procedureNamePattern) {
     return createEmptyResultSet(MetaProcedure.class);
   }
 
-  public MetaResultSet getProcedureColumns(String catalog,
+  public MetaResultSet getProcedureColumns(ConnectionHandle ch,
+      String catalog,
       Pat schemaPattern,
       Pat procedureNamePattern,
       Pat columnNamePattern) {
     return createEmptyResultSet(MetaProcedureColumn.class);
   }
 
-  public MetaResultSet getColumnPrivileges(String catalog,
+  public MetaResultSet getColumnPrivileges(ConnectionHandle ch,
+      String catalog,
       String schema,
       String table,
       Pat columnNamePattern) {
     return createEmptyResultSet(MetaColumnPrivilege.class);
   }
 
-  public MetaResultSet getTablePrivileges(String catalog,
+  public MetaResultSet getTablePrivileges(ConnectionHandle ch,
+      String catalog,
       Pat schemaPattern,
       Pat tableNamePattern) {
     return createEmptyResultSet(MetaTablePrivilege.class);
   }
 
-  public MetaResultSet getBestRowIdentifier(String catalog,
+  public MetaResultSet getBestRowIdentifier(ConnectionHandle ch,
+      String catalog,
       String schema,
       String table,
       int scope,
@@ -633,31 +643,36 @@ public abstract class MetaImpl implements Meta {
     return createEmptyResultSet(MetaBestRowIdentifier.class);
   }
 
-  public MetaResultSet getVersionColumns(String catalog,
+  public MetaResultSet getVersionColumns(ConnectionHandle ch,
+      String catalog,
       String schema,
       String table) {
     return createEmptyResultSet(MetaVersionColumn.class);
   }
 
-  public MetaResultSet getPrimaryKeys(String catalog,
+  public MetaResultSet getPrimaryKeys(ConnectionHandle ch,
+      String catalog,
       String schema,
       String table) {
     return createEmptyResultSet(MetaPrimaryKey.class);
   }
 
-  public MetaResultSet getImportedKeys(String catalog,
+  public MetaResultSet getImportedKeys(ConnectionHandle ch,
+      String catalog,
       String schema,
       String table) {
     return createEmptyResultSet(MetaImportedKey.class);
   }
 
-  public MetaResultSet getExportedKeys(String catalog,
+  public MetaResultSet getExportedKeys(ConnectionHandle ch,
+      String catalog,
       String schema,
       String table) {
     return createEmptyResultSet(MetaExportedKey.class);
   }
 
-  public MetaResultSet getCrossReference(String parentCatalog,
+  public MetaResultSet getCrossReference(ConnectionHandle ch,
+      String parentCatalog,
       String parentSchema,
       String parentTable,
       String foreignCatalog,
@@ -666,11 +681,12 @@ public abstract class MetaImpl implements Meta {
     return createEmptyResultSet(MetaCrossReference.class);
   }
 
-  public MetaResultSet getTypeInfo() {
+  public MetaResultSet getTypeInfo(ConnectionHandle ch) {
     return createEmptyResultSet(MetaTypeInfo.class);
   }
 
-  public MetaResultSet getIndexInfo(String catalog,
+  public MetaResultSet getIndexInfo(ConnectionHandle ch,
+      String catalog,
       String schema,
       String table,
       boolean unique,
@@ -678,50 +694,57 @@ public abstract class MetaImpl implements Meta {
     return createEmptyResultSet(MetaIndexInfo.class);
   }
 
-  public MetaResultSet getUDTs(String catalog,
+  public MetaResultSet getUDTs(ConnectionHandle ch,
+      String catalog,
       Pat schemaPattern,
       Pat typeNamePattern,
       int[] types) {
     return createEmptyResultSet(MetaUdt.class);
   }
 
-  public MetaResultSet getSuperTypes(String catalog,
+  public MetaResultSet getSuperTypes(ConnectionHandle ch,
+      String catalog,
       Pat schemaPattern,
       Pat typeNamePattern) {
     return createEmptyResultSet(MetaSuperType.class);
   }
 
-  public MetaResultSet getSuperTables(String catalog,
+  public MetaResultSet getSuperTables(ConnectionHandle ch,
+      String catalog,
       Pat schemaPattern,
       Pat tableNamePattern) {
     return createEmptyResultSet(MetaSuperTable.class);
   }
 
-  public MetaResultSet getAttributes(String catalog,
+  public MetaResultSet getAttributes(ConnectionHandle ch,
+      String catalog,
       Pat schemaPattern,
       Pat typeNamePattern,
       Pat attributeNamePattern) {
     return createEmptyResultSet(MetaAttribute.class);
   }
 
-  public MetaResultSet getClientInfoProperties() {
+  public MetaResultSet getClientInfoProperties(ConnectionHandle ch) {
     return createEmptyResultSet(MetaClientInfoProperty.class);
   }
 
-  public MetaResultSet getFunctions(String catalog,
+  public MetaResultSet getFunctions(ConnectionHandle ch,
+      String catalog,
       Pat schemaPattern,
       Pat functionNamePattern) {
     return createEmptyResultSet(MetaFunction.class);
   }
 
-  public MetaResultSet getFunctionColumns(String catalog,
+  public MetaResultSet getFunctionColumns(ConnectionHandle ch,
+      String catalog,
       Pat schemaPattern,
       Pat functionNamePattern,
       Pat columnNamePattern) {
     return createEmptyResultSet(MetaFunctionColumn.class);
   }
 
-  public MetaResultSet getPseudoColumns(String catalog,
+  public MetaResultSet getPseudoColumns(ConnectionHandle ch,
+      String catalog,
       Pat schemaPattern,
       Pat tableNamePattern,
       Pat columnNamePattern) {

--- a/avatica/src/main/java/org/apache/calcite/avatica/proto/Requests.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/proto/Requests.java
@@ -27,6 +27,16 @@ package org.apache.calcite.avatica.proto;
   public interface CatalogsRequestOrBuilder extends
       // @@protoc_insertion_point(interface_extends:CatalogsRequest)
       com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    java.lang.String getConnectionId();
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getConnectionIdBytes();
   }
   /**
    * Protobuf type {@code CatalogsRequest}
@@ -44,6 +54,7 @@ package org.apache.calcite.avatica.proto;
       super(builder);
     }
     private CatalogsRequest() {
+      connectionId_ = "";
     }
 
     @java.lang.Override
@@ -56,6 +67,7 @@ package org.apache.calcite.avatica.proto;
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
+      int mutable_bitField0_ = 0;
       try {
         boolean done = false;
         while (!done) {
@@ -68,6 +80,12 @@ package org.apache.calcite.avatica.proto;
               if (!input.skipField(tag)) {
                 done = true;
               }
+              break;
+            }
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+
+              connectionId_ = bs;
               break;
             }
           }
@@ -108,6 +126,42 @@ package org.apache.calcite.avatica.proto;
       return PARSER;
     }
 
+    public static final int CONNECTION_ID_FIELD_NUMBER = 1;
+    private java.lang.Object connectionId_;
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    public java.lang.String getConnectionId() {
+      java.lang.Object ref = connectionId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          connectionId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getConnectionIdBytes() {
+      java.lang.Object ref = connectionId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        connectionId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
@@ -121,6 +175,9 @@ package org.apache.calcite.avatica.proto;
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
+      if (!getConnectionIdBytes().isEmpty()) {
+        output.writeBytes(1, getConnectionIdBytes());
+      }
     }
 
     private int memoizedSerializedSize = -1;
@@ -129,6 +186,10 @@ package org.apache.calcite.avatica.proto;
       if (size != -1) return size;
 
       size = 0;
+      if (!getConnectionIdBytes().isEmpty()) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(1, getConnectionIdBytes());
+      }
       memoizedSerializedSize = size;
       return size;
     }
@@ -239,6 +300,8 @@ package org.apache.calcite.avatica.proto;
       }
       public Builder clear() {
         super.clear();
+        connectionId_ = "";
+
         return this;
       }
 
@@ -261,6 +324,7 @@ package org.apache.calcite.avatica.proto;
 
       public org.apache.calcite.avatica.proto.Requests.CatalogsRequest buildPartial() {
         org.apache.calcite.avatica.proto.Requests.CatalogsRequest result = new org.apache.calcite.avatica.proto.Requests.CatalogsRequest(this);
+        result.connectionId_ = connectionId_;
         onBuilt();
         return result;
       }
@@ -276,6 +340,10 @@ package org.apache.calcite.avatica.proto;
 
       public Builder mergeFrom(org.apache.calcite.avatica.proto.Requests.CatalogsRequest other) {
         if (other == org.apache.calcite.avatica.proto.Requests.CatalogsRequest.getDefaultInstance()) return this;
+        if (!other.getConnectionId().isEmpty()) {
+          connectionId_ = other.connectionId_;
+          onChanged();
+        }
         onChanged();
         return this;
       }
@@ -299,6 +367,76 @@ package org.apache.calcite.avatica.proto;
             mergeFrom(parsedMessage);
           }
         }
+        return this;
+      }
+
+      private java.lang.Object connectionId_ = "";
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public java.lang.String getConnectionId() {
+        java.lang.Object ref = connectionId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            connectionId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getConnectionIdBytes() {
+        java.lang.Object ref = connectionId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          connectionId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public Builder setConnectionId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        connectionId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public Builder clearConnectionId() {
+        
+        connectionId_ = getDefaultInstance().getConnectionId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public Builder setConnectionIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        connectionId_ = value;
+        onChanged();
         return this;
       }
       public final Builder setUnknownFields(
@@ -333,6 +471,16 @@ package org.apache.calcite.avatica.proto;
   public interface DatabasePropertyRequestOrBuilder extends
       // @@protoc_insertion_point(interface_extends:DatabasePropertyRequest)
       com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    java.lang.String getConnectionId();
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getConnectionIdBytes();
   }
   /**
    * Protobuf type {@code DatabasePropertyRequest}
@@ -350,6 +498,7 @@ package org.apache.calcite.avatica.proto;
       super(builder);
     }
     private DatabasePropertyRequest() {
+      connectionId_ = "";
     }
 
     @java.lang.Override
@@ -362,6 +511,7 @@ package org.apache.calcite.avatica.proto;
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
+      int mutable_bitField0_ = 0;
       try {
         boolean done = false;
         while (!done) {
@@ -374,6 +524,12 @@ package org.apache.calcite.avatica.proto;
               if (!input.skipField(tag)) {
                 done = true;
               }
+              break;
+            }
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+
+              connectionId_ = bs;
               break;
             }
           }
@@ -414,6 +570,42 @@ package org.apache.calcite.avatica.proto;
       return PARSER;
     }
 
+    public static final int CONNECTION_ID_FIELD_NUMBER = 1;
+    private java.lang.Object connectionId_;
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    public java.lang.String getConnectionId() {
+      java.lang.Object ref = connectionId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          connectionId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getConnectionIdBytes() {
+      java.lang.Object ref = connectionId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        connectionId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
@@ -427,6 +619,9 @@ package org.apache.calcite.avatica.proto;
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
+      if (!getConnectionIdBytes().isEmpty()) {
+        output.writeBytes(1, getConnectionIdBytes());
+      }
     }
 
     private int memoizedSerializedSize = -1;
@@ -435,6 +630,10 @@ package org.apache.calcite.avatica.proto;
       if (size != -1) return size;
 
       size = 0;
+      if (!getConnectionIdBytes().isEmpty()) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(1, getConnectionIdBytes());
+      }
       memoizedSerializedSize = size;
       return size;
     }
@@ -545,6 +744,8 @@ package org.apache.calcite.avatica.proto;
       }
       public Builder clear() {
         super.clear();
+        connectionId_ = "";
+
         return this;
       }
 
@@ -567,6 +768,7 @@ package org.apache.calcite.avatica.proto;
 
       public org.apache.calcite.avatica.proto.Requests.DatabasePropertyRequest buildPartial() {
         org.apache.calcite.avatica.proto.Requests.DatabasePropertyRequest result = new org.apache.calcite.avatica.proto.Requests.DatabasePropertyRequest(this);
+        result.connectionId_ = connectionId_;
         onBuilt();
         return result;
       }
@@ -582,6 +784,10 @@ package org.apache.calcite.avatica.proto;
 
       public Builder mergeFrom(org.apache.calcite.avatica.proto.Requests.DatabasePropertyRequest other) {
         if (other == org.apache.calcite.avatica.proto.Requests.DatabasePropertyRequest.getDefaultInstance()) return this;
+        if (!other.getConnectionId().isEmpty()) {
+          connectionId_ = other.connectionId_;
+          onChanged();
+        }
         onChanged();
         return this;
       }
@@ -605,6 +811,76 @@ package org.apache.calcite.avatica.proto;
             mergeFrom(parsedMessage);
           }
         }
+        return this;
+      }
+
+      private java.lang.Object connectionId_ = "";
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public java.lang.String getConnectionId() {
+        java.lang.Object ref = connectionId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            connectionId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getConnectionIdBytes() {
+        java.lang.Object ref = connectionId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          connectionId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public Builder setConnectionId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        connectionId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public Builder clearConnectionId() {
+        
+        connectionId_ = getDefaultInstance().getConnectionId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public Builder setConnectionIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        connectionId_ = value;
+        onChanged();
         return this;
       }
       public final Builder setUnknownFields(
@@ -659,6 +935,16 @@ package org.apache.calcite.avatica.proto;
      */
     com.google.protobuf.ByteString
         getSchemaPatternBytes();
+
+    /**
+     * <code>optional string connection_id = 3;</code>
+     */
+    java.lang.String getConnectionId();
+    /**
+     * <code>optional string connection_id = 3;</code>
+     */
+    com.google.protobuf.ByteString
+        getConnectionIdBytes();
   }
   /**
    * Protobuf type {@code SchemasRequest}
@@ -678,6 +964,7 @@ package org.apache.calcite.avatica.proto;
     private SchemasRequest() {
       catalog_ = "";
       schemaPattern_ = "";
+      connectionId_ = "";
     }
 
     @java.lang.Override
@@ -715,6 +1002,12 @@ package org.apache.calcite.avatica.proto;
               com.google.protobuf.ByteString bs = input.readBytes();
 
               schemaPattern_ = bs;
+              break;
+            }
+            case 26: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+
+              connectionId_ = bs;
               break;
             }
           }
@@ -827,6 +1120,42 @@ package org.apache.calcite.avatica.proto;
       }
     }
 
+    public static final int CONNECTION_ID_FIELD_NUMBER = 3;
+    private java.lang.Object connectionId_;
+    /**
+     * <code>optional string connection_id = 3;</code>
+     */
+    public java.lang.String getConnectionId() {
+      java.lang.Object ref = connectionId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          connectionId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string connection_id = 3;</code>
+     */
+    public com.google.protobuf.ByteString
+        getConnectionIdBytes() {
+      java.lang.Object ref = connectionId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        connectionId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
@@ -846,6 +1175,9 @@ package org.apache.calcite.avatica.proto;
       if (!getSchemaPatternBytes().isEmpty()) {
         output.writeBytes(2, getSchemaPatternBytes());
       }
+      if (!getConnectionIdBytes().isEmpty()) {
+        output.writeBytes(3, getConnectionIdBytes());
+      }
     }
 
     private int memoizedSerializedSize = -1;
@@ -861,6 +1193,10 @@ package org.apache.calcite.avatica.proto;
       if (!getSchemaPatternBytes().isEmpty()) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, getSchemaPatternBytes());
+      }
+      if (!getConnectionIdBytes().isEmpty()) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(3, getConnectionIdBytes());
       }
       memoizedSerializedSize = size;
       return size;
@@ -976,6 +1312,8 @@ package org.apache.calcite.avatica.proto;
 
         schemaPattern_ = "";
 
+        connectionId_ = "";
+
         return this;
       }
 
@@ -1000,6 +1338,7 @@ package org.apache.calcite.avatica.proto;
         org.apache.calcite.avatica.proto.Requests.SchemasRequest result = new org.apache.calcite.avatica.proto.Requests.SchemasRequest(this);
         result.catalog_ = catalog_;
         result.schemaPattern_ = schemaPattern_;
+        result.connectionId_ = connectionId_;
         onBuilt();
         return result;
       }
@@ -1021,6 +1360,10 @@ package org.apache.calcite.avatica.proto;
         }
         if (!other.getSchemaPattern().isEmpty()) {
           schemaPattern_ = other.schemaPattern_;
+          onChanged();
+        }
+        if (!other.getConnectionId().isEmpty()) {
+          connectionId_ = other.connectionId_;
           onChanged();
         }
         onChanged();
@@ -1188,6 +1531,76 @@ package org.apache.calcite.avatica.proto;
         onChanged();
         return this;
       }
+
+      private java.lang.Object connectionId_ = "";
+      /**
+       * <code>optional string connection_id = 3;</code>
+       */
+      public java.lang.String getConnectionId() {
+        java.lang.Object ref = connectionId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            connectionId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string connection_id = 3;</code>
+       */
+      public com.google.protobuf.ByteString
+          getConnectionIdBytes() {
+        java.lang.Object ref = connectionId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          connectionId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string connection_id = 3;</code>
+       */
+      public Builder setConnectionId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        connectionId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string connection_id = 3;</code>
+       */
+      public Builder clearConnectionId() {
+        
+        connectionId_ = getDefaultInstance().getConnectionId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string connection_id = 3;</code>
+       */
+      public Builder setConnectionIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        connectionId_ = value;
+        onChanged();
+        return this;
+      }
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return this;
@@ -1278,6 +1691,16 @@ package org.apache.calcite.avatica.proto;
      * </pre>
      */
     boolean getHasTypeList();
+
+    /**
+     * <code>optional string connection_id = 7;</code>
+     */
+    java.lang.String getConnectionId();
+    /**
+     * <code>optional string connection_id = 7;</code>
+     */
+    com.google.protobuf.ByteString
+        getConnectionIdBytes();
   }
   /**
    * Protobuf type {@code TablesRequest}
@@ -1301,6 +1724,7 @@ package org.apache.calcite.avatica.proto;
       tableNamePattern_ = "";
       typeList_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       hasTypeList_ = false;
+      connectionId_ = "";
     }
 
     @java.lang.Override
@@ -1358,6 +1782,12 @@ package org.apache.calcite.avatica.proto;
             case 48: {
 
               hasTypeList_ = input.readBool();
+              break;
+            }
+            case 58: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+
+              connectionId_ = bs;
               break;
             }
           }
@@ -1552,6 +1982,42 @@ package org.apache.calcite.avatica.proto;
       return hasTypeList_;
     }
 
+    public static final int CONNECTION_ID_FIELD_NUMBER = 7;
+    private java.lang.Object connectionId_;
+    /**
+     * <code>optional string connection_id = 7;</code>
+     */
+    public java.lang.String getConnectionId() {
+      java.lang.Object ref = connectionId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          connectionId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string connection_id = 7;</code>
+     */
+    public com.google.protobuf.ByteString
+        getConnectionIdBytes() {
+      java.lang.Object ref = connectionId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        connectionId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
@@ -1579,6 +2045,9 @@ package org.apache.calcite.avatica.proto;
       }
       if (hasTypeList_ != false) {
         output.writeBool(6, hasTypeList_);
+      }
+      if (!getConnectionIdBytes().isEmpty()) {
+        output.writeBytes(7, getConnectionIdBytes());
       }
     }
 
@@ -1612,6 +2081,10 @@ package org.apache.calcite.avatica.proto;
       if (hasTypeList_ != false) {
         size += com.google.protobuf.CodedOutputStream
           .computeBoolSize(6, hasTypeList_);
+      }
+      if (!getConnectionIdBytes().isEmpty()) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(7, getConnectionIdBytes());
       }
       memoizedSerializedSize = size;
       return size;
@@ -1734,6 +2207,8 @@ package org.apache.calcite.avatica.proto;
         bitField0_ = (bitField0_ & ~0x00000008);
         hasTypeList_ = false;
 
+        connectionId_ = "";
+
         return this;
       }
 
@@ -1767,6 +2242,7 @@ package org.apache.calcite.avatica.proto;
         }
         result.typeList_ = typeList_;
         result.hasTypeList_ = hasTypeList_;
+        result.connectionId_ = connectionId_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -1807,6 +2283,10 @@ package org.apache.calcite.avatica.proto;
         }
         if (other.getHasTypeList() != false) {
           setHasTypeList(other.getHasTypeList());
+        }
+        if (!other.getConnectionId().isEmpty()) {
+          connectionId_ = other.connectionId_;
+          onChanged();
         }
         onChanged();
         return this;
@@ -2175,6 +2655,76 @@ package org.apache.calcite.avatica.proto;
         onChanged();
         return this;
       }
+
+      private java.lang.Object connectionId_ = "";
+      /**
+       * <code>optional string connection_id = 7;</code>
+       */
+      public java.lang.String getConnectionId() {
+        java.lang.Object ref = connectionId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            connectionId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string connection_id = 7;</code>
+       */
+      public com.google.protobuf.ByteString
+          getConnectionIdBytes() {
+        java.lang.Object ref = connectionId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          connectionId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string connection_id = 7;</code>
+       */
+      public Builder setConnectionId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        connectionId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string connection_id = 7;</code>
+       */
+      public Builder clearConnectionId() {
+        
+        connectionId_ = getDefaultInstance().getConnectionId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string connection_id = 7;</code>
+       */
+      public Builder setConnectionIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        connectionId_ = value;
+        onChanged();
+        return this;
+      }
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return this;
@@ -2207,6 +2757,16 @@ package org.apache.calcite.avatica.proto;
   public interface TableTypesRequestOrBuilder extends
       // @@protoc_insertion_point(interface_extends:TableTypesRequest)
       com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    java.lang.String getConnectionId();
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getConnectionIdBytes();
   }
   /**
    * Protobuf type {@code TableTypesRequest}
@@ -2224,6 +2784,7 @@ package org.apache.calcite.avatica.proto;
       super(builder);
     }
     private TableTypesRequest() {
+      connectionId_ = "";
     }
 
     @java.lang.Override
@@ -2236,6 +2797,7 @@ package org.apache.calcite.avatica.proto;
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
+      int mutable_bitField0_ = 0;
       try {
         boolean done = false;
         while (!done) {
@@ -2248,6 +2810,12 @@ package org.apache.calcite.avatica.proto;
               if (!input.skipField(tag)) {
                 done = true;
               }
+              break;
+            }
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+
+              connectionId_ = bs;
               break;
             }
           }
@@ -2288,6 +2856,42 @@ package org.apache.calcite.avatica.proto;
       return PARSER;
     }
 
+    public static final int CONNECTION_ID_FIELD_NUMBER = 1;
+    private java.lang.Object connectionId_;
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    public java.lang.String getConnectionId() {
+      java.lang.Object ref = connectionId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          connectionId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getConnectionIdBytes() {
+      java.lang.Object ref = connectionId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        connectionId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
@@ -2301,6 +2905,9 @@ package org.apache.calcite.avatica.proto;
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
+      if (!getConnectionIdBytes().isEmpty()) {
+        output.writeBytes(1, getConnectionIdBytes());
+      }
     }
 
     private int memoizedSerializedSize = -1;
@@ -2309,6 +2916,10 @@ package org.apache.calcite.avatica.proto;
       if (size != -1) return size;
 
       size = 0;
+      if (!getConnectionIdBytes().isEmpty()) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(1, getConnectionIdBytes());
+      }
       memoizedSerializedSize = size;
       return size;
     }
@@ -2419,6 +3030,8 @@ package org.apache.calcite.avatica.proto;
       }
       public Builder clear() {
         super.clear();
+        connectionId_ = "";
+
         return this;
       }
 
@@ -2441,6 +3054,7 @@ package org.apache.calcite.avatica.proto;
 
       public org.apache.calcite.avatica.proto.Requests.TableTypesRequest buildPartial() {
         org.apache.calcite.avatica.proto.Requests.TableTypesRequest result = new org.apache.calcite.avatica.proto.Requests.TableTypesRequest(this);
+        result.connectionId_ = connectionId_;
         onBuilt();
         return result;
       }
@@ -2456,6 +3070,10 @@ package org.apache.calcite.avatica.proto;
 
       public Builder mergeFrom(org.apache.calcite.avatica.proto.Requests.TableTypesRequest other) {
         if (other == org.apache.calcite.avatica.proto.Requests.TableTypesRequest.getDefaultInstance()) return this;
+        if (!other.getConnectionId().isEmpty()) {
+          connectionId_ = other.connectionId_;
+          onChanged();
+        }
         onChanged();
         return this;
       }
@@ -2479,6 +3097,76 @@ package org.apache.calcite.avatica.proto;
             mergeFrom(parsedMessage);
           }
         }
+        return this;
+      }
+
+      private java.lang.Object connectionId_ = "";
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public java.lang.String getConnectionId() {
+        java.lang.Object ref = connectionId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            connectionId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getConnectionIdBytes() {
+        java.lang.Object ref = connectionId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          connectionId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public Builder setConnectionId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        connectionId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public Builder clearConnectionId() {
+        
+        connectionId_ = getDefaultInstance().getConnectionId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public Builder setConnectionIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        connectionId_ = value;
+        onChanged();
         return this;
       }
       public final Builder setUnknownFields(
@@ -2553,6 +3241,16 @@ package org.apache.calcite.avatica.proto;
      */
     com.google.protobuf.ByteString
         getColumnNamePatternBytes();
+
+    /**
+     * <code>optional string connection_id = 5;</code>
+     */
+    java.lang.String getConnectionId();
+    /**
+     * <code>optional string connection_id = 5;</code>
+     */
+    com.google.protobuf.ByteString
+        getConnectionIdBytes();
   }
   /**
    * Protobuf type {@code ColumnsRequest}
@@ -2575,6 +3273,7 @@ package org.apache.calcite.avatica.proto;
       schemaPattern_ = "";
       tableNamePattern_ = "";
       columnNamePattern_ = "";
+      connectionId_ = "";
     }
 
     @java.lang.Override
@@ -2624,6 +3323,12 @@ package org.apache.calcite.avatica.proto;
               com.google.protobuf.ByteString bs = input.readBytes();
 
               columnNamePattern_ = bs;
+              break;
+            }
+            case 42: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+
+              connectionId_ = bs;
               break;
             }
           }
@@ -2808,6 +3513,42 @@ package org.apache.calcite.avatica.proto;
       }
     }
 
+    public static final int CONNECTION_ID_FIELD_NUMBER = 5;
+    private java.lang.Object connectionId_;
+    /**
+     * <code>optional string connection_id = 5;</code>
+     */
+    public java.lang.String getConnectionId() {
+      java.lang.Object ref = connectionId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          connectionId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string connection_id = 5;</code>
+     */
+    public com.google.protobuf.ByteString
+        getConnectionIdBytes() {
+      java.lang.Object ref = connectionId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        connectionId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
@@ -2833,6 +3574,9 @@ package org.apache.calcite.avatica.proto;
       if (!getColumnNamePatternBytes().isEmpty()) {
         output.writeBytes(4, getColumnNamePatternBytes());
       }
+      if (!getConnectionIdBytes().isEmpty()) {
+        output.writeBytes(5, getConnectionIdBytes());
+      }
     }
 
     private int memoizedSerializedSize = -1;
@@ -2856,6 +3600,10 @@ package org.apache.calcite.avatica.proto;
       if (!getColumnNamePatternBytes().isEmpty()) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(4, getColumnNamePatternBytes());
+      }
+      if (!getConnectionIdBytes().isEmpty()) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(5, getConnectionIdBytes());
       }
       memoizedSerializedSize = size;
       return size;
@@ -2976,6 +3724,8 @@ package org.apache.calcite.avatica.proto;
 
         columnNamePattern_ = "";
 
+        connectionId_ = "";
+
         return this;
       }
 
@@ -3002,6 +3752,7 @@ package org.apache.calcite.avatica.proto;
         result.schemaPattern_ = schemaPattern_;
         result.tableNamePattern_ = tableNamePattern_;
         result.columnNamePattern_ = columnNamePattern_;
+        result.connectionId_ = connectionId_;
         onBuilt();
         return result;
       }
@@ -3031,6 +3782,10 @@ package org.apache.calcite.avatica.proto;
         }
         if (!other.getColumnNamePattern().isEmpty()) {
           columnNamePattern_ = other.columnNamePattern_;
+          onChanged();
+        }
+        if (!other.getConnectionId().isEmpty()) {
+          connectionId_ = other.connectionId_;
           onChanged();
         }
         onChanged();
@@ -3338,6 +4093,76 @@ package org.apache.calcite.avatica.proto;
         onChanged();
         return this;
       }
+
+      private java.lang.Object connectionId_ = "";
+      /**
+       * <code>optional string connection_id = 5;</code>
+       */
+      public java.lang.String getConnectionId() {
+        java.lang.Object ref = connectionId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            connectionId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string connection_id = 5;</code>
+       */
+      public com.google.protobuf.ByteString
+          getConnectionIdBytes() {
+        java.lang.Object ref = connectionId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          connectionId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string connection_id = 5;</code>
+       */
+      public Builder setConnectionId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        connectionId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string connection_id = 5;</code>
+       */
+      public Builder clearConnectionId() {
+        
+        connectionId_ = getDefaultInstance().getConnectionId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string connection_id = 5;</code>
+       */
+      public Builder setConnectionIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        connectionId_ = value;
+        onChanged();
+        return this;
+      }
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return this;
@@ -3370,6 +4195,16 @@ package org.apache.calcite.avatica.proto;
   public interface TypeInfoRequestOrBuilder extends
       // @@protoc_insertion_point(interface_extends:TypeInfoRequest)
       com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    java.lang.String getConnectionId();
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getConnectionIdBytes();
   }
   /**
    * Protobuf type {@code TypeInfoRequest}
@@ -3387,6 +4222,7 @@ package org.apache.calcite.avatica.proto;
       super(builder);
     }
     private TypeInfoRequest() {
+      connectionId_ = "";
     }
 
     @java.lang.Override
@@ -3399,6 +4235,7 @@ package org.apache.calcite.avatica.proto;
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
+      int mutable_bitField0_ = 0;
       try {
         boolean done = false;
         while (!done) {
@@ -3411,6 +4248,12 @@ package org.apache.calcite.avatica.proto;
               if (!input.skipField(tag)) {
                 done = true;
               }
+              break;
+            }
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+
+              connectionId_ = bs;
               break;
             }
           }
@@ -3451,6 +4294,42 @@ package org.apache.calcite.avatica.proto;
       return PARSER;
     }
 
+    public static final int CONNECTION_ID_FIELD_NUMBER = 1;
+    private java.lang.Object connectionId_;
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    public java.lang.String getConnectionId() {
+      java.lang.Object ref = connectionId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          connectionId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getConnectionIdBytes() {
+      java.lang.Object ref = connectionId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        connectionId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
@@ -3464,6 +4343,9 @@ package org.apache.calcite.avatica.proto;
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
+      if (!getConnectionIdBytes().isEmpty()) {
+        output.writeBytes(1, getConnectionIdBytes());
+      }
     }
 
     private int memoizedSerializedSize = -1;
@@ -3472,6 +4354,10 @@ package org.apache.calcite.avatica.proto;
       if (size != -1) return size;
 
       size = 0;
+      if (!getConnectionIdBytes().isEmpty()) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(1, getConnectionIdBytes());
+      }
       memoizedSerializedSize = size;
       return size;
     }
@@ -3582,6 +4468,8 @@ package org.apache.calcite.avatica.proto;
       }
       public Builder clear() {
         super.clear();
+        connectionId_ = "";
+
         return this;
       }
 
@@ -3604,6 +4492,7 @@ package org.apache.calcite.avatica.proto;
 
       public org.apache.calcite.avatica.proto.Requests.TypeInfoRequest buildPartial() {
         org.apache.calcite.avatica.proto.Requests.TypeInfoRequest result = new org.apache.calcite.avatica.proto.Requests.TypeInfoRequest(this);
+        result.connectionId_ = connectionId_;
         onBuilt();
         return result;
       }
@@ -3619,6 +4508,10 @@ package org.apache.calcite.avatica.proto;
 
       public Builder mergeFrom(org.apache.calcite.avatica.proto.Requests.TypeInfoRequest other) {
         if (other == org.apache.calcite.avatica.proto.Requests.TypeInfoRequest.getDefaultInstance()) return this;
+        if (!other.getConnectionId().isEmpty()) {
+          connectionId_ = other.connectionId_;
+          onChanged();
+        }
         onChanged();
         return this;
       }
@@ -3642,6 +4535,76 @@ package org.apache.calcite.avatica.proto;
             mergeFrom(parsedMessage);
           }
         }
+        return this;
+      }
+
+      private java.lang.Object connectionId_ = "";
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public java.lang.String getConnectionId() {
+        java.lang.Object ref = connectionId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            connectionId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getConnectionIdBytes() {
+        java.lang.Object ref = connectionId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          connectionId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public Builder setConnectionId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        connectionId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public Builder clearConnectionId() {
+        
+        connectionId_ = getDefaultInstance().getConnectionId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public Builder setConnectionIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        connectionId_ = value;
+        onChanged();
         return this;
       }
       public final Builder setUnknownFields(
@@ -7156,6 +8119,560 @@ package org.apache.calcite.avatica.proto;
 
   }
 
+  public interface OpenConnectionRequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:OpenConnectionRequest)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    java.lang.String getConnectionId();
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getConnectionIdBytes();
+
+    /**
+     * <code>map&lt;string, string&gt; info = 2;</code>
+     */
+    java.util.Map<java.lang.String, java.lang.String>
+    getInfo();
+  }
+  /**
+   * Protobuf type {@code OpenConnectionRequest}
+   *
+   * <pre>
+   * Request for Meta#openConnection(Meta.ConnectionHandle, Map&lt;String, String&gt;)
+   * </pre>
+   */
+  public  static final class OpenConnectionRequest extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:OpenConnectionRequest)
+      OpenConnectionRequestOrBuilder {
+    // Use OpenConnectionRequest.newBuilder() to construct.
+    private OpenConnectionRequest(com.google.protobuf.GeneratedMessage.Builder builder) {
+      super(builder);
+    }
+    private OpenConnectionRequest() {
+      connectionId_ = "";
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return com.google.protobuf.UnknownFieldSet.getDefaultInstance();
+    }
+    private OpenConnectionRequest(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      int mutable_bitField0_ = 0;
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!input.skipField(tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+
+              connectionId_ = bs;
+              break;
+            }
+            case 18: {
+              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+                info_ = com.google.protobuf.MapField.newMapField(
+                    infoDefaultEntry);
+                mutable_bitField0_ |= 0x00000002;
+              }
+              com.google.protobuf.MapEntry<java.lang.String, java.lang.String>
+              info = input.readMessage(
+                  infoDefaultEntry.getParserForType(), extensionRegistry);
+              info_.getMutableMap().put(info.getKey(), info.getValue());
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.apache.calcite.avatica.proto.Requests.internal_static_OpenConnectionRequest_descriptor;
+    }
+
+    @SuppressWarnings({"rawtypes"})
+    protected com.google.protobuf.MapField internalGetMapField(
+        int number) {
+      switch (number) {
+        case 2:
+          return info_;
+        default:
+          throw new RuntimeException(
+              "Invalid map field number: " + number);
+      }
+    }
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.apache.calcite.avatica.proto.Requests.internal_static_OpenConnectionRequest_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest.class, org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest.Builder.class);
+    }
+
+    public static final com.google.protobuf.Parser<OpenConnectionRequest> PARSER =
+        new com.google.protobuf.AbstractParser<OpenConnectionRequest>() {
+      public OpenConnectionRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new OpenConnectionRequest(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<OpenConnectionRequest> getParserForType() {
+      return PARSER;
+    }
+
+    private int bitField0_;
+    public static final int CONNECTION_ID_FIELD_NUMBER = 1;
+    private java.lang.Object connectionId_;
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    public java.lang.String getConnectionId() {
+      java.lang.Object ref = connectionId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          connectionId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getConnectionIdBytes() {
+      java.lang.Object ref = connectionId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        connectionId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int INFO_FIELD_NUMBER = 2;
+    private static final com.google.protobuf.MapEntry<
+        java.lang.String, java.lang.String> infoDefaultEntry =
+            com.google.protobuf.MapEntry
+            .<java.lang.String, java.lang.String>newDefaultInstance(
+                org.apache.calcite.avatica.proto.Requests.internal_static_OpenConnectionRequest_InfoEntry_descriptor, 
+                com.google.protobuf.WireFormat.FieldType.STRING,
+                "",
+                com.google.protobuf.WireFormat.FieldType.STRING,
+                "");
+    private com.google.protobuf.MapField<
+        java.lang.String, java.lang.String> info_ =
+            com.google.protobuf.MapField.emptyMapField(
+                infoDefaultEntry);
+
+    /**
+     * <code>map&lt;string, string&gt; info = 2;</code>
+     */
+
+    public java.util.Map<java.lang.String, java.lang.String> getInfo() {
+      return info_.getMap();
+    }
+
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (!getConnectionIdBytes().isEmpty()) {
+        output.writeBytes(1, getConnectionIdBytes());
+      }
+      for (java.util.Map.Entry<java.lang.String, java.lang.String> entry
+           : info_.getMap().entrySet()) {
+        com.google.protobuf.MapEntry<java.lang.String, java.lang.String>
+        info = infoDefaultEntry.newBuilderForType()
+            .setKey(entry.getKey())
+            .setValue(entry.getValue())
+            .build();
+        output.writeMessage(2, info);
+      }
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!getConnectionIdBytes().isEmpty()) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(1, getConnectionIdBytes());
+      }
+      for (java.util.Map.Entry<java.lang.String, java.lang.String> entry
+           : info_.getMap().entrySet()) {
+        com.google.protobuf.MapEntry<java.lang.String, java.lang.String>
+        info = infoDefaultEntry.newBuilderForType()
+            .setKey(entry.getKey())
+            .setValue(entry.getValue())
+            .build();
+        size += com.google.protobuf.CodedOutputStream
+            .computeMessageSize(2, info);
+      }
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    public static org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return new Builder(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code OpenConnectionRequest}
+     *
+     * <pre>
+     * Request for Meta#openConnection(Meta.ConnectionHandle, Map&lt;String, String&gt;)
+     * </pre>
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:OpenConnectionRequest)
+        org.apache.calcite.avatica.proto.Requests.OpenConnectionRequestOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.apache.calcite.avatica.proto.Requests.internal_static_OpenConnectionRequest_descriptor;
+      }
+
+      @SuppressWarnings({"rawtypes"})
+      protected com.google.protobuf.MapField internalGetMapField(
+          int number) {
+        switch (number) {
+          case 2:
+            return info_;
+          default:
+            throw new RuntimeException(
+                "Invalid map field number: " + number);
+        }
+      }
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.apache.calcite.avatica.proto.Requests.internal_static_OpenConnectionRequest_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest.class, org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest.Builder.class);
+      }
+
+      // Construct using org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      public Builder clear() {
+        super.clear();
+        connectionId_ = "";
+
+        info_.clear();
+        return this;
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.calcite.avatica.proto.Requests.internal_static_OpenConnectionRequest_descriptor;
+      }
+
+      public org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest getDefaultInstanceForType() {
+        return org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest.getDefaultInstance();
+      }
+
+      public org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest build() {
+        org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest buildPartial() {
+        org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest result = new org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        result.connectionId_ = connectionId_;
+        result.info_ = info_.copy();
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest) {
+          return mergeFrom((org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest other) {
+        if (other == org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest.getDefaultInstance()) return this;
+        if (!other.getConnectionId().isEmpty()) {
+          connectionId_ = other.connectionId_;
+          onChanged();
+        }
+        info_.mergeFrom(other.info_);
+        onChanged();
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object connectionId_ = "";
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public java.lang.String getConnectionId() {
+        java.lang.Object ref = connectionId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            connectionId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getConnectionIdBytes() {
+        java.lang.Object ref = connectionId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          connectionId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public Builder setConnectionId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        connectionId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public Builder clearConnectionId() {
+        
+        connectionId_ = getDefaultInstance().getConnectionId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public Builder setConnectionIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        connectionId_ = value;
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.MapField<
+          java.lang.String, java.lang.String> info_ =
+              com.google.protobuf.MapField.newMapField(
+                  infoDefaultEntry);
+
+      /**
+       * <code>map&lt;string, string&gt; info = 2;</code>
+       */
+      public java.util.Map<java.lang.String, java.lang.String> getInfo() {
+        return info_.getMap();
+      }
+      /**
+       * <code>map&lt;string, string&gt; info = 2;</code>
+       */
+      public java.util.Map<java.lang.String, java.lang.String>
+      getMutableInfo() {
+        onChanged();
+        return info_.getMutableMap();
+      }
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return this;
+      }
+
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return this;
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:OpenConnectionRequest)
+    }
+
+    // @@protoc_insertion_point(class_scope:OpenConnectionRequest)
+    private static final org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest defaultInstance;static {
+      defaultInstance = new org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest();
+    }
+
+    public static org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+  }
+
   public interface CloseConnectionRequestOrBuilder extends
       // @@protoc_insertion_point(interface_extends:CloseConnectionRequest)
       com.google.protobuf.MessageOrBuilder {
@@ -8282,6 +9799,16 @@ package org.apache.calcite.avatica.proto;
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_CloseStatementRequest_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_OpenConnectionRequest_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_OpenConnectionRequest_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_OpenConnectionRequest_InfoEntry_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_OpenConnectionRequest_InfoEntry_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_CloseConnectionRequest_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
@@ -8300,34 +9827,41 @@ package org.apache.calcite.avatica.proto;
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\016requests.proto\032\014common.proto\"\021\n\017Catalo" +
-      "gsRequest\"\031\n\027DatabasePropertyRequest\"9\n\016" +
-      "SchemasRequest\022\017\n\007catalog\030\001 \001(\t\022\026\n\016schem" +
-      "a_pattern\030\002 \001(\t\"~\n\rTablesRequest\022\017\n\007cata" +
-      "log\030\001 \001(\t\022\026\n\016schema_pattern\030\002 \001(\t\022\032\n\022tab" +
-      "le_name_pattern\030\003 \001(\t\022\021\n\ttype_list\030\004 \003(\t" +
-      "\022\025\n\rhas_type_list\030\006 \001(\010\"\023\n\021TableTypesReq" +
-      "uest\"r\n\016ColumnsRequest\022\017\n\007catalog\030\001 \001(\t\022" +
+      "\n\016requests.proto\032\014common.proto\"(\n\017Catalo" +
+      "gsRequest\022\025\n\rconnection_id\030\001 \001(\t\"0\n\027Data" +
+      "basePropertyRequest\022\025\n\rconnection_id\030\001 \001" +
+      "(\t\"P\n\016SchemasRequest\022\017\n\007catalog\030\001 \001(\t\022\026\n" +
+      "\016schema_pattern\030\002 \001(\t\022\025\n\rconnection_id\030\003" +
+      " \001(\t\"\225\001\n\rTablesRequest\022\017\n\007catalog\030\001 \001(\t\022" +
       "\026\n\016schema_pattern\030\002 \001(\t\022\032\n\022table_name_pa" +
-      "ttern\030\003 \001(\t\022\033\n\023column_name_pattern\030\004 \001(\t",
-      "\"\021\n\017TypeInfoRequest\"k\n\030PrepareAndExecute" +
-      "Request\022\025\n\rconnection_id\030\001 \001(\t\022\013\n\003sql\030\002 " +
-      "\001(\t\022\025\n\rmax_row_count\030\003 \001(\004\022\024\n\014statement_" +
-      "id\030\004 \001(\r\"K\n\016PrepareRequest\022\025\n\rconnection" +
-      "_id\030\001 \001(\t\022\013\n\003sql\030\002 \001(\t\022\025\n\rmax_row_count\030" +
-      "\003 \001(\004\"\255\001\n\014FetchRequest\022\025\n\rconnection_id\030" +
-      "\001 \001(\t\022\024\n\014statement_id\030\002 \001(\r\022\016\n\006offset\030\003 " +
-      "\001(\004\022\033\n\023fetch_max_row_count\030\004 \001(\r\022%\n\020para" +
-      "meter_values\030\005 \003(\0132\013.TypedValue\022\034\n\024has_p" +
-      "arameter_values\030\006 \001(\010\"/\n\026CreateStatement",
-      "Request\022\025\n\rconnection_id\030\001 \001(\t\"D\n\025CloseS" +
-      "tatementRequest\022\025\n\rconnection_id\030\001 \001(\t\022\024" +
-      "\n\014statement_id\030\002 \001(\r\"/\n\026CloseConnectionR" +
-      "equest\022\025\n\rconnection_id\030\001 \001(\t\"Y\n\025Connect" +
-      "ionSyncRequest\022\025\n\rconnection_id\030\001 \001(\t\022)\n" +
-      "\nconn_props\030\002 \001(\0132\025.ConnectionProperties" +
-      "B\"\n org.apache.calcite.avatica.protob\006pr" +
-      "oto3"
+      "ttern\030\003 \001(\t\022\021\n\ttype_list\030\004 \003(\t\022\025\n\rhas_ty" +
+      "pe_list\030\006 \001(\010\022\025\n\rconnection_id\030\007 \001(\t\"*\n\021" +
+      "TableTypesRequest\022\025\n\rconnection_id\030\001 \001(\t",
+      "\"\211\001\n\016ColumnsRequest\022\017\n\007catalog\030\001 \001(\t\022\026\n\016" +
+      "schema_pattern\030\002 \001(\t\022\032\n\022table_name_patte" +
+      "rn\030\003 \001(\t\022\033\n\023column_name_pattern\030\004 \001(\t\022\025\n" +
+      "\rconnection_id\030\005 \001(\t\"(\n\017TypeInfoRequest\022" +
+      "\025\n\rconnection_id\030\001 \001(\t\"k\n\030PrepareAndExec" +
+      "uteRequest\022\025\n\rconnection_id\030\001 \001(\t\022\013\n\003sql" +
+      "\030\002 \001(\t\022\025\n\rmax_row_count\030\003 \001(\004\022\024\n\014stateme" +
+      "nt_id\030\004 \001(\r\"K\n\016PrepareRequest\022\025\n\rconnect" +
+      "ion_id\030\001 \001(\t\022\013\n\003sql\030\002 \001(\t\022\025\n\rmax_row_cou" +
+      "nt\030\003 \001(\004\"\255\001\n\014FetchRequest\022\025\n\rconnection_",
+      "id\030\001 \001(\t\022\024\n\014statement_id\030\002 \001(\r\022\016\n\006offset" +
+      "\030\003 \001(\004\022\033\n\023fetch_max_row_count\030\004 \001(\r\022%\n\020p" +
+      "arameter_values\030\005 \003(\0132\013.TypedValue\022\034\n\024ha" +
+      "s_parameter_values\030\006 \001(\010\"/\n\026CreateStatem" +
+      "entRequest\022\025\n\rconnection_id\030\001 \001(\t\"D\n\025Clo" +
+      "seStatementRequest\022\025\n\rconnection_id\030\001 \001(" +
+      "\t\022\024\n\014statement_id\030\002 \001(\r\"\213\001\n\025OpenConnecti" +
+      "onRequest\022\025\n\rconnection_id\030\001 \001(\t\022.\n\004info" +
+      "\030\002 \003(\0132 .OpenConnectionRequest.InfoEntry" +
+      "\032+\n\tInfoEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(",
+      "\t:\0028\001\"/\n\026CloseConnectionRequest\022\025\n\rconne" +
+      "ction_id\030\001 \001(\t\"Y\n\025ConnectionSyncRequest\022" +
+      "\025\n\rconnection_id\030\001 \001(\t\022)\n\nconn_props\030\002 \001" +
+      "(\0132\025.ConnectionPropertiesB\"\n org.apache." +
+      "calcite.avatica.protob\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -8347,43 +9881,43 @@ package org.apache.calcite.avatica.proto;
     internal_static_CatalogsRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_CatalogsRequest_descriptor,
-        new java.lang.String[] { });
+        new java.lang.String[] { "ConnectionId", });
     internal_static_DatabasePropertyRequest_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_DatabasePropertyRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_DatabasePropertyRequest_descriptor,
-        new java.lang.String[] { });
+        new java.lang.String[] { "ConnectionId", });
     internal_static_SchemasRequest_descriptor =
       getDescriptor().getMessageTypes().get(2);
     internal_static_SchemasRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_SchemasRequest_descriptor,
-        new java.lang.String[] { "Catalog", "SchemaPattern", });
+        new java.lang.String[] { "Catalog", "SchemaPattern", "ConnectionId", });
     internal_static_TablesRequest_descriptor =
       getDescriptor().getMessageTypes().get(3);
     internal_static_TablesRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_TablesRequest_descriptor,
-        new java.lang.String[] { "Catalog", "SchemaPattern", "TableNamePattern", "TypeList", "HasTypeList", });
+        new java.lang.String[] { "Catalog", "SchemaPattern", "TableNamePattern", "TypeList", "HasTypeList", "ConnectionId", });
     internal_static_TableTypesRequest_descriptor =
       getDescriptor().getMessageTypes().get(4);
     internal_static_TableTypesRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_TableTypesRequest_descriptor,
-        new java.lang.String[] { });
+        new java.lang.String[] { "ConnectionId", });
     internal_static_ColumnsRequest_descriptor =
       getDescriptor().getMessageTypes().get(5);
     internal_static_ColumnsRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_ColumnsRequest_descriptor,
-        new java.lang.String[] { "Catalog", "SchemaPattern", "TableNamePattern", "ColumnNamePattern", });
+        new java.lang.String[] { "Catalog", "SchemaPattern", "TableNamePattern", "ColumnNamePattern", "ConnectionId", });
     internal_static_TypeInfoRequest_descriptor =
       getDescriptor().getMessageTypes().get(6);
     internal_static_TypeInfoRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_TypeInfoRequest_descriptor,
-        new java.lang.String[] { });
+        new java.lang.String[] { "ConnectionId", });
     internal_static_PrepareAndExecuteRequest_descriptor =
       getDescriptor().getMessageTypes().get(7);
     internal_static_PrepareAndExecuteRequest_fieldAccessorTable = new
@@ -8414,14 +9948,26 @@ package org.apache.calcite.avatica.proto;
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_CloseStatementRequest_descriptor,
         new java.lang.String[] { "ConnectionId", "StatementId", });
-    internal_static_CloseConnectionRequest_descriptor =
+    internal_static_OpenConnectionRequest_descriptor =
       getDescriptor().getMessageTypes().get(12);
+    internal_static_OpenConnectionRequest_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_OpenConnectionRequest_descriptor,
+        new java.lang.String[] { "ConnectionId", "Info", });
+    internal_static_OpenConnectionRequest_InfoEntry_descriptor =
+      internal_static_OpenConnectionRequest_descriptor.getNestedTypes().get(0);
+    internal_static_OpenConnectionRequest_InfoEntry_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_OpenConnectionRequest_InfoEntry_descriptor,
+        new java.lang.String[] { "Key", "Value", });
+    internal_static_CloseConnectionRequest_descriptor =
+      getDescriptor().getMessageTypes().get(13);
     internal_static_CloseConnectionRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_CloseConnectionRequest_descriptor,
         new java.lang.String[] { "ConnectionId", });
     internal_static_ConnectionSyncRequest_descriptor =
-      getDescriptor().getMessageTypes().get(13);
+      getDescriptor().getMessageTypes().get(14);
     internal_static_ConnectionSyncRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_ConnectionSyncRequest_descriptor,

--- a/avatica/src/main/java/org/apache/calcite/avatica/proto/Responses.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/proto/Responses.java
@@ -3497,6 +3497,312 @@ package org.apache.calcite.avatica.proto;
 
   }
 
+  public interface OpenConnectionResponseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:OpenConnectionResponse)
+      com.google.protobuf.MessageOrBuilder {
+  }
+  /**
+   * Protobuf type {@code OpenConnectionResponse}
+   *
+   * <pre>
+   * Response to OpenConnectionRequest {
+   * </pre>
+   */
+  public  static final class OpenConnectionResponse extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:OpenConnectionResponse)
+      OpenConnectionResponseOrBuilder {
+    // Use OpenConnectionResponse.newBuilder() to construct.
+    private OpenConnectionResponse(com.google.protobuf.GeneratedMessage.Builder builder) {
+      super(builder);
+    }
+    private OpenConnectionResponse() {
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return com.google.protobuf.UnknownFieldSet.getDefaultInstance();
+    }
+    private OpenConnectionResponse(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!input.skipField(tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.apache.calcite.avatica.proto.Responses.internal_static_OpenConnectionResponse_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.apache.calcite.avatica.proto.Responses.internal_static_OpenConnectionResponse_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse.class, org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse.Builder.class);
+    }
+
+    public static final com.google.protobuf.Parser<OpenConnectionResponse> PARSER =
+        new com.google.protobuf.AbstractParser<OpenConnectionResponse>() {
+      public OpenConnectionResponse parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new OpenConnectionResponse(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<OpenConnectionResponse> getParserForType() {
+      return PARSER;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    public static org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return new Builder(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code OpenConnectionResponse}
+     *
+     * <pre>
+     * Response to OpenConnectionRequest {
+     * </pre>
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:OpenConnectionResponse)
+        org.apache.calcite.avatica.proto.Responses.OpenConnectionResponseOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.apache.calcite.avatica.proto.Responses.internal_static_OpenConnectionResponse_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.apache.calcite.avatica.proto.Responses.internal_static_OpenConnectionResponse_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse.class, org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse.Builder.class);
+      }
+
+      // Construct using org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      public Builder clear() {
+        super.clear();
+        return this;
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.calcite.avatica.proto.Responses.internal_static_OpenConnectionResponse_descriptor;
+      }
+
+      public org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse getDefaultInstanceForType() {
+        return org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse.getDefaultInstance();
+      }
+
+      public org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse build() {
+        org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse buildPartial() {
+        org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse result = new org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse(this);
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse) {
+          return mergeFrom((org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse other) {
+        if (other == org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse.getDefaultInstance()) return this;
+        onChanged();
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return this;
+      }
+
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return this;
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:OpenConnectionResponse)
+    }
+
+    // @@protoc_insertion_point(class_scope:OpenConnectionResponse)
+    private static final org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse defaultInstance;static {
+      defaultInstance = new org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse();
+    }
+
+    public static org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+  }
+
   public interface CloseConnectionResponseOrBuilder extends
       // @@protoc_insertion_point(interface_extends:CloseConnectionResponse)
       com.google.protobuf.MessageOrBuilder {
@@ -5633,6 +5939,442 @@ package org.apache.calcite.avatica.proto;
 
   }
 
+  public interface ErrorResponseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:ErrorResponse)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional string message = 1;</code>
+     */
+    java.lang.String getMessage();
+    /**
+     * <code>optional string message = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getMessageBytes();
+  }
+  /**
+   * Protobuf type {@code ErrorResponse}
+   */
+  public  static final class ErrorResponse extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:ErrorResponse)
+      ErrorResponseOrBuilder {
+    // Use ErrorResponse.newBuilder() to construct.
+    private ErrorResponse(com.google.protobuf.GeneratedMessage.Builder builder) {
+      super(builder);
+    }
+    private ErrorResponse() {
+      message_ = "";
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return com.google.protobuf.UnknownFieldSet.getDefaultInstance();
+    }
+    private ErrorResponse(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      int mutable_bitField0_ = 0;
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!input.skipField(tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+
+              message_ = bs;
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.apache.calcite.avatica.proto.Responses.internal_static_ErrorResponse_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.apache.calcite.avatica.proto.Responses.internal_static_ErrorResponse_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.calcite.avatica.proto.Responses.ErrorResponse.class, org.apache.calcite.avatica.proto.Responses.ErrorResponse.Builder.class);
+    }
+
+    public static final com.google.protobuf.Parser<ErrorResponse> PARSER =
+        new com.google.protobuf.AbstractParser<ErrorResponse>() {
+      public ErrorResponse parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new ErrorResponse(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<ErrorResponse> getParserForType() {
+      return PARSER;
+    }
+
+    public static final int MESSAGE_FIELD_NUMBER = 1;
+    private java.lang.Object message_;
+    /**
+     * <code>optional string message = 1;</code>
+     */
+    public java.lang.String getMessage() {
+      java.lang.Object ref = message_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          message_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string message = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getMessageBytes() {
+      java.lang.Object ref = message_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        message_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (!getMessageBytes().isEmpty()) {
+        output.writeBytes(1, getMessageBytes());
+      }
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!getMessageBytes().isEmpty()) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(1, getMessageBytes());
+      }
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    public static org.apache.calcite.avatica.proto.Responses.ErrorResponse parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.ErrorResponse parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.ErrorResponse parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.ErrorResponse parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.ErrorResponse parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.ErrorResponse parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.ErrorResponse parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.ErrorResponse parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.ErrorResponse parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.ErrorResponse parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return new Builder(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.apache.calcite.avatica.proto.Responses.ErrorResponse prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code ErrorResponse}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:ErrorResponse)
+        org.apache.calcite.avatica.proto.Responses.ErrorResponseOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.apache.calcite.avatica.proto.Responses.internal_static_ErrorResponse_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.apache.calcite.avatica.proto.Responses.internal_static_ErrorResponse_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.calcite.avatica.proto.Responses.ErrorResponse.class, org.apache.calcite.avatica.proto.Responses.ErrorResponse.Builder.class);
+      }
+
+      // Construct using org.apache.calcite.avatica.proto.Responses.ErrorResponse.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      public Builder clear() {
+        super.clear();
+        message_ = "";
+
+        return this;
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.calcite.avatica.proto.Responses.internal_static_ErrorResponse_descriptor;
+      }
+
+      public org.apache.calcite.avatica.proto.Responses.ErrorResponse getDefaultInstanceForType() {
+        return org.apache.calcite.avatica.proto.Responses.ErrorResponse.getDefaultInstance();
+      }
+
+      public org.apache.calcite.avatica.proto.Responses.ErrorResponse build() {
+        org.apache.calcite.avatica.proto.Responses.ErrorResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public org.apache.calcite.avatica.proto.Responses.ErrorResponse buildPartial() {
+        org.apache.calcite.avatica.proto.Responses.ErrorResponse result = new org.apache.calcite.avatica.proto.Responses.ErrorResponse(this);
+        result.message_ = message_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.apache.calcite.avatica.proto.Responses.ErrorResponse) {
+          return mergeFrom((org.apache.calcite.avatica.proto.Responses.ErrorResponse)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.apache.calcite.avatica.proto.Responses.ErrorResponse other) {
+        if (other == org.apache.calcite.avatica.proto.Responses.ErrorResponse.getDefaultInstance()) return this;
+        if (!other.getMessage().isEmpty()) {
+          message_ = other.message_;
+          onChanged();
+        }
+        onChanged();
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.apache.calcite.avatica.proto.Responses.ErrorResponse parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.calcite.avatica.proto.Responses.ErrorResponse) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+
+      private java.lang.Object message_ = "";
+      /**
+       * <code>optional string message = 1;</code>
+       */
+      public java.lang.String getMessage() {
+        java.lang.Object ref = message_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            message_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string message = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getMessageBytes() {
+        java.lang.Object ref = message_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          message_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string message = 1;</code>
+       */
+      public Builder setMessage(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        message_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string message = 1;</code>
+       */
+      public Builder clearMessage() {
+        
+        message_ = getDefaultInstance().getMessage();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string message = 1;</code>
+       */
+      public Builder setMessageBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        message_ = value;
+        onChanged();
+        return this;
+      }
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return this;
+      }
+
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return this;
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:ErrorResponse)
+    }
+
+    // @@protoc_insertion_point(class_scope:ErrorResponse)
+    private static final org.apache.calcite.avatica.proto.Responses.ErrorResponse defaultInstance;static {
+      defaultInstance = new org.apache.calcite.avatica.proto.Responses.ErrorResponse();
+    }
+
+    public static org.apache.calcite.avatica.proto.Responses.ErrorResponse getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public org.apache.calcite.avatica.proto.Responses.ErrorResponse getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+  }
+
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_ResultSetResponse_descriptor;
   private static
@@ -5664,6 +6406,11 @@ package org.apache.calcite.avatica.proto;
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_CloseStatementResponse_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_OpenConnectionResponse_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_OpenConnectionResponse_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_CloseConnectionResponse_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
@@ -5683,6 +6430,11 @@ package org.apache.calcite.avatica.proto;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_DatabasePropertyResponse_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_ErrorResponse_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_ErrorResponse_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -5703,14 +6455,16 @@ package org.apache.calcite.avatica.proto;
       "etchResponse\022\025\n\005frame\030\001 \001(\0132\006.Frame\"F\n\027C" +
       "reateStatementResponse\022\025\n\rconnection_id\030",
       "\001 \001(\t\022\024\n\014statement_id\030\002 \001(\r\"\030\n\026CloseStat" +
-      "ementResponse\"\031\n\027CloseConnectionResponse" +
-      "\"C\n\026ConnectionSyncResponse\022)\n\nconn_props" +
-      "\030\001 \001(\0132\025.ConnectionProperties\"U\n\027Databas" +
-      "ePropertyElement\022\036\n\003key\030\001 \001(\0132\021.Database" +
-      "Property\022\032\n\005value\030\002 \001(\0132\013.TypedValue\"C\n\030" +
-      "DatabasePropertyResponse\022\'\n\005props\030\001 \003(\0132" +
-      "\030.DatabasePropertyElementB\"\n org.apache." +
-      "calcite.avatica.protob\006proto3"
+      "ementResponse\"\030\n\026OpenConnectionResponse\"" +
+      "\031\n\027CloseConnectionResponse\"C\n\026Connection" +
+      "SyncResponse\022)\n\nconn_props\030\001 \001(\0132\025.Conne" +
+      "ctionProperties\"U\n\027DatabasePropertyEleme" +
+      "nt\022\036\n\003key\030\001 \001(\0132\021.DatabaseProperty\022\032\n\005va" +
+      "lue\030\002 \001(\0132\013.TypedValue\"C\n\030DatabaseProper" +
+      "tyResponse\022\'\n\005props\030\001 \003(\0132\030.DatabaseProp" +
+      "ertyElement\" \n\rErrorResponse\022\017\n\007message\030" +
+      "\001 \001(\tB\"\n org.apache.calcite.avatica.prot",
+      "ob\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -5761,30 +6515,42 @@ package org.apache.calcite.avatica.proto;
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_CloseStatementResponse_descriptor,
         new java.lang.String[] { });
-    internal_static_CloseConnectionResponse_descriptor =
+    internal_static_OpenConnectionResponse_descriptor =
       getDescriptor().getMessageTypes().get(6);
+    internal_static_OpenConnectionResponse_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_OpenConnectionResponse_descriptor,
+        new java.lang.String[] { });
+    internal_static_CloseConnectionResponse_descriptor =
+      getDescriptor().getMessageTypes().get(7);
     internal_static_CloseConnectionResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_CloseConnectionResponse_descriptor,
         new java.lang.String[] { });
     internal_static_ConnectionSyncResponse_descriptor =
-      getDescriptor().getMessageTypes().get(7);
+      getDescriptor().getMessageTypes().get(8);
     internal_static_ConnectionSyncResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_ConnectionSyncResponse_descriptor,
         new java.lang.String[] { "ConnProps", });
     internal_static_DatabasePropertyElement_descriptor =
-      getDescriptor().getMessageTypes().get(8);
+      getDescriptor().getMessageTypes().get(9);
     internal_static_DatabasePropertyElement_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_DatabasePropertyElement_descriptor,
         new java.lang.String[] { "Key", "Value", });
     internal_static_DatabasePropertyResponse_descriptor =
-      getDescriptor().getMessageTypes().get(9);
+      getDescriptor().getMessageTypes().get(10);
     internal_static_DatabasePropertyResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_DatabasePropertyResponse_descriptor,
         new java.lang.String[] { "Props", });
+    internal_static_ErrorResponse_descriptor =
+      getDescriptor().getMessageTypes().get(11);
+    internal_static_ErrorResponse_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_ErrorResponse_descriptor,
+        new java.lang.String[] { "Message", });
     org.apache.calcite.avatica.proto.Common.getDescriptor();
   }
 

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/Driver.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/Driver.java
@@ -26,10 +26,15 @@ import org.apache.calcite.avatica.UnregisteredDriver;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 /**
  * Avatica Remote JDBC driver.
@@ -76,6 +81,15 @@ public class Driver extends UnregisteredDriver {
 
   @Override public Meta createMeta(AvaticaConnection connection) {
     final ConnectionConfig config = connection.config();
+    final Service service = createService(config);
+    return new RemoteMeta(connection, service);
+  }
+
+  private Service createService(ConnectionConfig config) {
+    // Exploit that none of the factory implementations currently rely
+    // on connection being there.
+    AvaticaConnection connection = null;
+
     final Service.Factory metaFactory = config.factory();
     final Service service;
     if (metaFactory != null) {
@@ -103,7 +117,40 @@ public class Driver extends UnregisteredDriver {
     } else {
       service = new MockJsonService(Collections.<String, String>emptyMap());
     }
-    return new RemoteMeta(connection, service);
+    return service;
+  }
+
+  @Override
+  public Connection connect(String url, Properties info) throws SQLException {
+    AvaticaConnection conn = (AvaticaConnection) super.connect(url, info);
+    if (conn == null) {
+      // It's not an url for our driver
+      return null;
+    }
+
+    // Create the corresponding remote connection
+    ConnectionConfig config = conn.config();
+    Service service = createService(config);
+
+    Map<String, String> infoAsString = new HashMap<>();
+    for (Map.Entry<Object, Object> entry : info.entrySet()) {
+      // Determine if this is a property we want to forward to the server
+      boolean localProperty = false;
+      for (BuiltInConnectionProperty prop : BuiltInConnectionProperty.values()) {
+        if (prop.camelName().equals(entry.getKey())) {
+          localProperty = true;
+          break;
+        }
+      }
+
+      if (!localProperty) {
+        infoAsString.put(entry.getKey().toString(), entry.getValue().toString());
+      }
+    }
+
+    service.apply(new Service.OpenConnectionRequest(conn.id, infoAsString));
+
+    return conn;
   }
 
   private Serialization getSerialization(ConnectionConfig config) {

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/JsonHandler.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/JsonHandler.java
@@ -51,7 +51,7 @@ public class JsonHandler implements Handler<String> {
     return MAPPER.readValue(request, valueType);
   }
 
-  private <T> String encode(T response) throws IOException {
+  public <T> String encode(T response) throws IOException {
     final StringWriter w = new StringWriter();
     MAPPER.writeValue(w, response);
     return w.toString();

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/JsonService.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/JsonService.java
@@ -148,6 +148,14 @@ public abstract class JsonService extends AbstractService {
     }
   }
 
+  public OpenConnectionResponse apply(OpenConnectionRequest request) {
+    try {
+      return decode(apply(encode(request)), OpenConnectionResponse.class);
+    } catch (IOException e) {
+      throw handle(e);
+    }
+  }
+
   public CloseConnectionResponse apply(CloseConnectionRequest request) {
     try {
       return decode(apply(encode(request)), CloseConnectionResponse.class);

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/LocalService.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/LocalService.java
@@ -88,19 +88,22 @@ public class LocalService implements Service {
   }
 
   public ResultSetResponse apply(CatalogsRequest request) {
-    final Meta.MetaResultSet resultSet = meta.getCatalogs();
+    final Meta.MetaResultSet resultSet =
+        meta.getCatalogs(new Meta.ConnectionHandle(request.connectionId));
     return toResponse(resultSet);
   }
 
   public ResultSetResponse apply(SchemasRequest request) {
     final Meta.MetaResultSet resultSet =
-        meta.getSchemas(request.catalog, Meta.Pat.of(request.schemaPattern));
+        meta.getSchemas(new Meta.ConnectionHandle(request.connectionId),
+            request.catalog, Meta.Pat.of(request.schemaPattern));
     return toResponse(resultSet);
   }
 
   public ResultSetResponse apply(TablesRequest request) {
     final Meta.MetaResultSet resultSet =
-        meta.getTables(request.catalog,
+        meta.getTables(new Meta.ConnectionHandle(request.connectionId),
+            request.catalog,
             Meta.Pat.of(request.schemaPattern),
             Meta.Pat.of(request.tableNamePattern),
             request.typeList);
@@ -108,18 +111,22 @@ public class LocalService implements Service {
   }
 
   public ResultSetResponse apply(TableTypesRequest request) {
-    final Meta.MetaResultSet resultSet = meta.getTableTypes();
+    final Meta.MetaResultSet resultSet = meta.getTableTypes(
+        new Meta.ConnectionHandle(request.connectionId));
     return toResponse(resultSet);
   }
 
   public ResultSetResponse apply(TypeInfoRequest request) {
-    final Meta.MetaResultSet resultSet = meta.getTypeInfo();
+    final Meta.MetaResultSet resultSet = meta.getTypeInfo(
+        new Meta.ConnectionHandle(request.connectionId));
     return toResponse(resultSet);
   }
 
   public ResultSetResponse apply(ColumnsRequest request) {
     final Meta.MetaResultSet resultSet =
-        meta.getColumns(request.catalog,
+        meta.getColumns(
+            new Meta.ConnectionHandle(request.connectionId),
+            request.catalog,
             Meta.Pat.of(request.schemaPattern),
             Meta.Pat.of(request.tableNamePattern),
             Meta.Pat.of(request.columnNamePattern));
@@ -185,6 +192,11 @@ public class LocalService implements Service {
     return new CloseStatementResponse();
   }
 
+  public OpenConnectionResponse apply(OpenConnectionRequest request) {
+    meta.openConnection(new Meta.ConnectionHandle(request.connectionId), request.info);
+    return new OpenConnectionResponse();
+  }
+
   public CloseConnectionResponse apply(CloseConnectionRequest request) {
     meta.closeConnection(new Meta.ConnectionHandle(request.connectionId));
     return new CloseConnectionResponse();
@@ -197,7 +209,8 @@ public class LocalService implements Service {
   }
 
   public DatabasePropertyResponse apply(DatabasePropertyRequest request) {
-    return new DatabasePropertyResponse(meta.getDatabaseProperties());
+    return new DatabasePropertyResponse(meta.getDatabaseProperties(
+        new Meta.ConnectionHandle(request.connectionId)));
   }
 }
 

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/MockProtobufService.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/MockProtobufService.java
@@ -40,13 +40,17 @@ public class MockProtobufService extends ProtobufService {
 
     // Add in mappings
 
+    mappings.put(
+        new OpenConnectionRequest("0", new HashMap<String, String>()),
+        new OpenConnectionResponse());
+
     // Get the schema, no.. schema..?
     mappings.put(
-        new SchemasRequest(null, null),
+        new SchemasRequest("0", null, null),
         new ResultSetResponse(null, 1, true, null, Meta.Frame.EMPTY, -1));
 
     // Get the tables, no tables exist
-    mappings.put(new TablesRequest(null, null, null, Collections.<String>emptyList()),
+    mappings.put(new TablesRequest("0", null, null, null, Collections.<String>emptyList()),
         new ResultSetResponse(null, 150, true, null, Meta.Frame.EMPTY, -1));
 
     // Create a statement, get back an id
@@ -98,6 +102,19 @@ public class MockProtobufService extends ProtobufService {
    * @throws RuntimeException if no mapping is found for the request
    */
   private Response dispatch(Request request) {
+    // Canonicalize connectionId's to 0
+    if (request instanceof OpenConnectionRequest) {
+      OpenConnectionRequest req = (OpenConnectionRequest) request;
+      request = new OpenConnectionRequest("0", req.info);
+    } else if (request instanceof TablesRequest) {
+      TablesRequest req = (TablesRequest) request;
+      request = new TablesRequest("0", req.catalog, req.schemaPattern,
+          req.tableNamePattern, req.typeList);
+    } else if (request instanceof SchemasRequest) {
+      SchemasRequest req = (SchemasRequest) request;
+      request = new SchemasRequest("0", req.catalog, req.schemaPattern);
+    }
+
     Response response = MAPPING.get(request);
 
     if (null == response) {

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/ProtobufService.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/ProtobufService.java
@@ -74,6 +74,11 @@ public abstract class ProtobufService extends AbstractService {
     return (CloseStatementResponse) _apply(request);
   }
 
+  @Override
+  public OpenConnectionResponse apply(OpenConnectionRequest request) {
+    return (OpenConnectionResponse) _apply(request);
+  }
+
   @Override public CloseConnectionResponse apply(CloseConnectionRequest request) {
     return (CloseConnectionResponse) _apply(request);
   }

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/ProtobufTranslationImpl.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/ProtobufTranslationImpl.java
@@ -25,6 +25,7 @@ import org.apache.calcite.avatica.proto.Requests.ConnectionSyncRequest;
 import org.apache.calcite.avatica.proto.Requests.CreateStatementRequest;
 import org.apache.calcite.avatica.proto.Requests.DatabasePropertyRequest;
 import org.apache.calcite.avatica.proto.Requests.FetchRequest;
+import org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest;
 import org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteRequest;
 import org.apache.calcite.avatica.proto.Requests.PrepareRequest;
 import org.apache.calcite.avatica.proto.Requests.SchemasRequest;
@@ -36,8 +37,10 @@ import org.apache.calcite.avatica.proto.Responses.CloseStatementResponse;
 import org.apache.calcite.avatica.proto.Responses.ConnectionSyncResponse;
 import org.apache.calcite.avatica.proto.Responses.CreateStatementResponse;
 import org.apache.calcite.avatica.proto.Responses.DatabasePropertyResponse;
+import org.apache.calcite.avatica.proto.Responses.ErrorResponse;
 import org.apache.calcite.avatica.proto.Responses.ExecuteResponse;
 import org.apache.calcite.avatica.proto.Responses.FetchResponse;
+import org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse;
 import org.apache.calcite.avatica.proto.Responses.PrepareResponse;
 import org.apache.calcite.avatica.proto.Responses.ResultSetResponse;
 import org.apache.calcite.avatica.remote.Service.Request;
@@ -68,6 +71,8 @@ public class ProtobufTranslationImpl implements ProtobufTranslation {
     HashMap<String, RequestTranslator> reqParsers = new HashMap<>();
     reqParsers.put(CatalogsRequest.class.getName(),
         new RequestTranslator(CatalogsRequest.PARSER, new Service.CatalogsRequest()));
+    reqParsers.put(OpenConnectionRequest.class.getName(),
+        new RequestTranslator(OpenConnectionRequest.PARSER, new Service.OpenConnectionRequest()));
     reqParsers.put(CloseConnectionRequest.class.getName(),
         new RequestTranslator(CloseConnectionRequest.PARSER, new Service.CloseConnectionRequest()));
     reqParsers.put(CloseStatementRequest.class.getName(),
@@ -100,6 +105,9 @@ public class ProtobufTranslationImpl implements ProtobufTranslation {
     REQUEST_PARSERS = Collections.unmodifiableMap(reqParsers);
 
     HashMap<String, ResponseTranslator> respParsers = new HashMap<>();
+    respParsers.put(OpenConnectionResponse.class.getName(),
+        new ResponseTranslator(OpenConnectionResponse.PARSER,
+            new Service.OpenConnectionResponse()));
     respParsers.put(CloseConnectionResponse.class.getName(),
         new ResponseTranslator(CloseConnectionResponse.PARSER,
             new Service.CloseConnectionResponse()));
@@ -123,6 +131,8 @@ public class ProtobufTranslationImpl implements ProtobufTranslation {
         new ResponseTranslator(PrepareResponse.PARSER, new Service.PrepareResponse()));
     respParsers.put(ResultSetResponse.class.getName(),
         new ResponseTranslator(ResultSetResponse.PARSER, new Service.ResultSetResponse()));
+    respParsers.put(ErrorResponse.class.getName(),
+        new ResponseTranslator(ErrorResponse.PARSER, new Service.ErrorResponse()));
 
     RESPONSE_PARSERS = Collections.unmodifiableMap(respParsers);
   }

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/RemoteMeta.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/RemoteMeta.java
@@ -62,12 +62,12 @@ class RemoteMeta extends MetaImpl {
         response.ownStatement, signature0, response.firstFrame);
   }
 
-  @Override public Map<DatabaseProperty, Object> getDatabaseProperties() {
+  @Override public Map<DatabaseProperty, Object> getDatabaseProperties(ConnectionHandle ch) {
     synchronized (this) {
       // Compute map on first use, and cache
       if (databaseProperties == null) {
         databaseProperties =
-            service.apply(new Service.DatabasePropertyRequest()).map;
+            service.apply(new Service.DatabasePropertyRequest(ch.id)).map;
       }
       return databaseProperties;
     }
@@ -84,6 +84,11 @@ class RemoteMeta extends MetaImpl {
   @Override public void closeStatement(StatementHandle h) {
     final Service.CloseStatementResponse response =
         service.apply(new Service.CloseStatementRequest(h.connectionId, h.id));
+  }
+
+  @Override public void openConnection(ConnectionHandle ch, Map<String, String> info) {
+    final Service.OpenConnectionResponse response =
+        service.apply(new Service.OpenConnectionRequest(ch.id, info));
   }
 
   @Override public void closeConnection(ConnectionHandle ch) {
@@ -115,44 +120,45 @@ class RemoteMeta extends MetaImpl {
     }
   }
 
-  @Override public MetaResultSet getCatalogs() {
+  @Override public MetaResultSet getCatalogs(ConnectionHandle ch) {
     final Service.ResultSetResponse response =
-        service.apply(new Service.CatalogsRequest());
+        service.apply(new Service.CatalogsRequest(ch.id));
     return toResultSet(MetaCatalog.class, response);
   }
 
-  @Override public MetaResultSet getSchemas(String catalog, Pat schemaPattern) {
+  @Override public MetaResultSet getSchemas(ConnectionHandle ch, String catalog,
+      Pat schemaPattern) {
     final Service.ResultSetResponse response =
-        service.apply(new Service.SchemasRequest(catalog, schemaPattern.s));
+        service.apply(new Service.SchemasRequest(ch.id, catalog, schemaPattern.s));
     return toResultSet(MetaSchema.class, response);
   }
 
-  @Override public MetaResultSet getTables(String catalog, Pat schemaPattern,
+  @Override public MetaResultSet getTables(ConnectionHandle ch, String catalog, Pat schemaPattern,
       Pat tableNamePattern, List<String> typeList) {
     final Service.ResultSetResponse response =
         service.apply(
-            new Service.TablesRequest(catalog, schemaPattern.s,
+            new Service.TablesRequest(ch.id, catalog, schemaPattern.s,
                 tableNamePattern.s, typeList));
     return toResultSet(MetaTable.class, response);
   }
 
-  @Override public MetaResultSet getTableTypes() {
+  @Override public MetaResultSet getTableTypes(ConnectionHandle ch) {
     final Service.ResultSetResponse response =
-        service.apply(new Service.TableTypesRequest());
+        service.apply(new Service.TableTypesRequest(ch.id));
     return toResultSet(MetaTableType.class, response);
   }
 
-  @Override public MetaResultSet getTypeInfo() {
+  @Override public MetaResultSet getTypeInfo(ConnectionHandle ch) {
     final Service.ResultSetResponse response =
-        service.apply(new Service.TypeInfoRequest());
+        service.apply(new Service.TypeInfoRequest(ch.id));
     return toResultSet(MetaTypeInfo.class, response);
   }
 
-  @Override public MetaResultSet getColumns(String catalog, Pat schemaPattern,
+  @Override public MetaResultSet getColumns(ConnectionHandle ch, String catalog, Pat schemaPattern,
       Pat tableNamePattern, Pat columnNamePattern) {
     final Service.ResultSetResponse response =
         service.apply(
-            new Service.ColumnsRequest(catalog, schemaPattern.s,
+            new Service.ColumnsRequest(ch.id, catalog, schemaPattern.s,
                 tableNamePattern.s, columnNamePattern.s));
     return toResultSet(MetaColumn.class, response);
   }

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/RemoteService.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/RemoteService.java
@@ -53,9 +53,16 @@ public class RemoteService extends JsonService {
           wr.close();
         }
       }
-      final int responseCode = connection.getResponseCode();
+      int responseCode = connection.getResponseCode();
       if (responseCode != HttpURLConnection.HTTP_OK) {
-        throw new RuntimeException("response code " + responseCode);
+        InputStream errorStream = connection.getErrorStream();
+        if (errorStream != null) {
+          String errorResponse = AvaticaUtils.readFully(errorStream);
+          ErrorResponse response = decode(errorResponse, ErrorResponse.class);
+          throw new RuntimeException("Remote driver error: " + response.message);
+        } else {
+          throw new RuntimeException("response code " + responseCode);
+        }
       }
       final InputStream inputStream = connection.getInputStream();
       return AvaticaUtils.readFully(inputStream);

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/Service.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/Service.java
@@ -51,6 +51,7 @@ public interface Service {
   FetchResponse apply(FetchRequest request);
   CreateStatementResponse apply(CreateStatementRequest request);
   CloseStatementResponse apply(CloseStatementRequest request);
+  OpenConnectionResponse apply(OpenConnectionRequest request);
   CloseConnectionResponse apply(CloseConnectionRequest request);
   ConnectionSyncResponse apply(ConnectionSyncRequest request);
   DatabasePropertyResponse apply(DatabasePropertyRequest request);
@@ -80,6 +81,8 @@ public interface Service {
           name = "createStatement"),
       @JsonSubTypes.Type(value = CloseStatementRequest.class,
           name = "closeStatement"),
+      @JsonSubTypes.Type(value = OpenConnectionRequest.class,
+          name = "openConnection"),
       @JsonSubTypes.Type(value = CloseConnectionRequest.class,
           name = "closeConnection"),
       @JsonSubTypes.Type(value = ConnectionSyncRequest.class, name = "connectionSync"),
@@ -96,6 +99,7 @@ public interface Service {
       property = "response",
       defaultImpl = ResultSetResponse.class)
   @JsonSubTypes({
+      @JsonSubTypes.Type(value = OpenConnectionResponse.class, name = "openConnection"),
       @JsonSubTypes.Type(value = ResultSetResponse.class, name = "resultSet"),
       @JsonSubTypes.Type(value = PrepareResponse.class, name = "prepare"),
       @JsonSubTypes.Type(value = FetchResponse.class, name = "fetch"),
@@ -114,8 +118,19 @@ public interface Service {
   }
 
   /** Request for
-   * {@link org.apache.calcite.avatica.Meta#getCatalogs()}. */
+   * {@link org.apache.calcite.avatica.Meta#getCatalogs(Meta.ConnectionHandle)}. */
   class CatalogsRequest extends Request {
+    public final String connectionId;
+
+    public CatalogsRequest() {
+      connectionId = null;
+    }
+
+    @JsonCreator
+    public CatalogsRequest(@JsonProperty("connectionId") String connectionId) {
+      this.connectionId = connectionId;
+    }
+
     ResultSetResponse accept(Service service) {
       return service.apply(this);
     }
@@ -126,31 +141,67 @@ public interface Service {
             "Expected CatalogsRequest, but got " + genericMsg.getClass().getName());
       }
 
-      // No state to set
-      return new CatalogsRequest();
+      final Requests.CatalogsRequest msg = (Requests.CatalogsRequest) genericMsg;
+      final Descriptor desc = msg.getDescriptorForType();
+
+      String connectionId = null;
+      if (ProtobufService.hasField(msg, desc,
+          Requests.CatalogsRequest.CONNECTION_ID_FIELD_NUMBER)) {
+        connectionId = msg.getConnectionId();
+      }
+
+      return new CatalogsRequest(connectionId);
     }
 
     @Override Requests.CatalogsRequest serialize() {
-      return Requests.CatalogsRequest.newBuilder().build();
+      Requests.CatalogsRequest.Builder builder = Requests.CatalogsRequest.newBuilder();
+
+      if (null != connectionId) {
+        builder.setConnectionId(connectionId);
+      }
+
+      return builder.build();
     }
 
     @Override public int hashCode() {
-      return 0;
+      return connectionId == null ? 0 : connectionId.hashCode();
     }
 
     @Override public boolean equals(Object o) {
       if (o == this) {
         return true;
       }
-      return o instanceof CatalogsRequest;
+
+      if (o instanceof CatalogsRequest) {
+        CatalogsRequest other = (CatalogsRequest) o;
+
+        if (null == connectionId) {
+          if (null != other.connectionId) {
+            return false;
+          }
+        } else if (!connectionId.equals(other.connectionId)) {
+          return false;
+        }
+
+        return true;
+      }
+
+      return false;
     }
   }
 
   /** Request for
-   * {@link org.apache.calcite.avatica.Meta#getDatabaseProperties()}. */
+   * {@link org.apache.calcite.avatica.Meta#getDatabaseProperties(Meta.ConnectionHandle)}. */
   class DatabasePropertyRequest extends Request {
-    @JsonCreator
+    public final String connectionId;
+
     public DatabasePropertyRequest() {
+      connectionId = null;
+    }
+
+    @JsonCreator
+    public DatabasePropertyRequest(@JsonProperty("connectionId") String connectionId) {
+      this.connectionId = connectionId;
     }
 
     DatabasePropertyResponse accept(Service service) {
@@ -163,38 +214,73 @@ public interface Service {
             "Expected DatabasePropertyRequest, but got " + genericMsg.getClass().getName());
       }
 
-      return new DatabasePropertyRequest();
+      final Requests.DatabasePropertyRequest msg = (Requests.DatabasePropertyRequest) genericMsg;
+      final Descriptor desc = msg.getDescriptorForType();
+
+      String connectionId = null;
+      if (ProtobufService.hasField(msg, desc,
+          Requests.DatabasePropertyRequest.CONNECTION_ID_FIELD_NUMBER)) {
+        connectionId = msg.getConnectionId();
+      }
+
+      return new DatabasePropertyRequest(connectionId);
     }
 
     @Override Requests.DatabasePropertyRequest serialize() {
-      return Requests.DatabasePropertyRequest.newBuilder().build();
+      Requests.DatabasePropertyRequest.Builder builder =
+          Requests.DatabasePropertyRequest.newBuilder();
+
+      if (null != connectionId) {
+        builder.setConnectionId(connectionId);
+      }
+
+      return builder.build();
     }
 
     @Override public int hashCode() {
-      return 0;
+      return connectionId == null ? 0 : connectionId.hashCode();
     }
 
     @Override public boolean equals(Object o) {
       if (o == this) {
         return true;
       }
-      return o instanceof DatabasePropertyRequest;
+
+      if (o instanceof DatabasePropertyRequest) {
+        DatabasePropertyRequest other = (DatabasePropertyRequest) o;
+
+        if (null == connectionId) {
+          if (null != other.connectionId) {
+            return false;
+          }
+        } else if (!connectionId.equals(other.connectionId)) {
+          return false;
+        }
+
+        return true;
+      }
+
+      return false;
     }
   }
   /** Request for
-   * {@link Meta#getSchemas(String, org.apache.calcite.avatica.Meta.Pat)}. */
+   * {@link Meta#getSchemas(Meta.ConnectionHandle, String, Meta.Pat)}. */
   class SchemasRequest extends Request {
+    public final String connectionId;
     public final String catalog;
     public final String schemaPattern;
 
     SchemasRequest() {
+      connectionId = null;
       catalog = null;
       schemaPattern = null;
     }
 
     @JsonCreator
-    public SchemasRequest(@JsonProperty("catalog") String catalog,
+    public SchemasRequest(@JsonProperty("connectionId") String connectionId,
+        @JsonProperty("catalog") String catalog,
         @JsonProperty("schemaPattern") String schemaPattern) {
+      this.connectionId = connectionId;
       this.catalog = catalog;
       this.schemaPattern = schemaPattern;
     }
@@ -212,6 +298,11 @@ public interface Service {
       final Requests.SchemasRequest msg = (Requests.SchemasRequest) genericMsg;
       final Descriptor desc = msg.getDescriptorForType();
 
+      String connectionId = null;
+      if (ProtobufService.hasField(msg, desc, Requests.SchemasRequest.CONNECTION_ID_FIELD_NUMBER)) {
+        connectionId = msg.getConnectionId();
+      }
+
       String catalog = null;
       if (ProtobufService.hasField(msg, desc, Requests.SchemasRequest.CATALOG_FIELD_NUMBER)) {
         catalog = msg.getCatalog();
@@ -223,11 +314,14 @@ public interface Service {
         schemaPattern = msg.getSchemaPattern();
       }
 
-      return new SchemasRequest(catalog, schemaPattern);
+      return new SchemasRequest(connectionId, catalog, schemaPattern);
     }
 
     @Override Requests.SchemasRequest serialize() {
       Requests.SchemasRequest.Builder builder = Requests.SchemasRequest.newBuilder();
+      if (null != connectionId) {
+        builder.setConnectionId(connectionId);
+      }
       if (null != catalog) {
         builder.setCatalog(catalog);
       }
@@ -241,6 +335,7 @@ public interface Service {
     @Override public int hashCode() {
       final int prime = 31;
       int result = 1;
+      result = prime * result + ((connectionId == null) ? 0 : connectionId.hashCode());
       result = prime * result + ((catalog == null) ? 0 : catalog.hashCode());
       result = prime * result + ((schemaPattern == null) ? 0 : schemaPattern.hashCode());
       return result;
@@ -252,6 +347,14 @@ public interface Service {
       }
       if (o instanceof SchemasRequest) {
         SchemasRequest other = (SchemasRequest) o;
+
+        if (null == connectionId) {
+          if (null != other.connectionId) {
+            return false;
+          }
+        } else if (!connectionId.equals(other.connectionId)) {
+          return false;
+        }
 
         if (null == catalog) {
           // We're null, other is not
@@ -279,15 +382,17 @@ public interface Service {
   }
 
   /** Request for
-   * {@link Meta#getTables(String, org.apache.calcite.avatica.Meta.Pat, org.apache.calcite.avatica.Meta.Pat, java.util.List)}
+   * {@link Meta#getTables(Meta.ConnectionHandle, String, org.apache.calcite.avatica.Meta.Pat, org.apache.calcite.avatica.Meta.Pat, java.util.List)}
    */
   class TablesRequest extends Request {
+    public final String connectionId;
     public final String catalog;
     public final String schemaPattern;
     public final String tableNamePattern;
     public final List<String> typeList;
 
     TablesRequest() {
+      connectionId = null;
       catalog = null;
       schemaPattern = null;
       tableNamePattern = null;
@@ -295,10 +400,12 @@ public interface Service {
     }
 
     @JsonCreator
-    public TablesRequest(@JsonProperty("catalog") String catalog,
+    public TablesRequest(@JsonProperty("connectionId") String connectionId,
+        @JsonProperty("catalog") String catalog,
         @JsonProperty("schemaPattern") String schemaPattern,
         @JsonProperty("tableNamePattern") String tableNamePattern,
         @JsonProperty("typeList") List<String> typeList) {
+      this.connectionId = connectionId;
       this.catalog = catalog;
       this.schemaPattern = schemaPattern;
       this.tableNamePattern = tableNamePattern;
@@ -317,6 +424,11 @@ public interface Service {
 
       final Requests.TablesRequest msg = (Requests.TablesRequest) genericMsg;
       final Descriptor desc = msg.getDescriptorForType();
+
+      String connectionId = null;
+      if (ProtobufService.hasField(msg, desc, Requests.TablesRequest.CONNECTION_ID_FIELD_NUMBER)) {
+        connectionId = msg.getConnectionId();
+      }
 
       String catalog = null;
       if (ProtobufService.hasField(msg, desc, Requests.TablesRequest.CATALOG_FIELD_NUMBER)) {
@@ -341,12 +453,15 @@ public interface Service {
         typeList = msg.getTypeListList();
       }
 
-      return new TablesRequest(catalog, schemaPattern, tableNamePattern, typeList);
+      return new TablesRequest(connectionId, catalog, schemaPattern, tableNamePattern, typeList);
     }
 
     @Override Requests.TablesRequest serialize() {
       Requests.TablesRequest.Builder builder = Requests.TablesRequest.newBuilder();
 
+      if (null != connectionId) {
+        builder.setConnectionId(connectionId);
+      }
       if (null != catalog) {
         builder.setCatalog(catalog);
       }
@@ -369,6 +484,7 @@ public interface Service {
     @Override public int hashCode() {
       final int prime = 31;
       int result = 1;
+      result = prime * result + ((connectionId == null) ? 0 : connectionId.hashCode());
       result = prime * result + ((catalog == null) ? 0 : catalog.hashCode());
       result = prime * result + ((schemaPattern == null) ? 0 : schemaPattern.hashCode());
       result = prime * result + ((tableNamePattern == null) ? 0 : tableNamePattern.hashCode());
@@ -383,8 +499,16 @@ public interface Service {
       if (o instanceof TablesRequest) {
         TablesRequest other = (TablesRequest) o;
 
+        if (null == connectionId) {
+          if (null != other.connectionId) {
+            return false;
+          }
+        } else if (!connectionId.equals(other.connectionId)) {
+          return false;
+        }
+
         if (null == catalog) {
-          if (null != catalog) {
+          if (null != other.catalog) {
             return false;
           }
         } else if (!catalog.equals(other.catalog)) {
@@ -423,9 +547,20 @@ public interface Service {
   }
 
   /**
-   * Request for {@link Meta#getTableTypes()}.
+   * Request for {@link Meta#getTableTypes(Meta.ConnectionHandle)}.
    */
   class TableTypesRequest extends Request {
+    public final String connectionId;
+
+    public TableTypesRequest() {
+      this.connectionId = null;
+    }
+
+    @JsonCreator
+    public TableTypesRequest(@JsonProperty("connectionId") String connectionId) {
+      this.connectionId = connectionId;
+    }
+
     @Override ResultSetResponse accept(Service service) {
       return service.apply(this);
     }
@@ -436,35 +571,65 @@ public interface Service {
             "Expected TableTypesRequest, but got " + genericMsg.getClass().getName());
       }
 
-      return new TableTypesRequest();
+      final Requests.TableTypesRequest msg = (Requests.TableTypesRequest) genericMsg;
+      final Descriptor desc = msg.getDescriptorForType();
+
+      String connectionId = null;
+      if (ProtobufService.hasField(msg, desc,
+          Requests.TableTypesRequest.CONNECTION_ID_FIELD_NUMBER)) {
+        connectionId = msg.getConnectionId();
+      }
+
+      return new TableTypesRequest(connectionId);
     }
 
     @Override Requests.TableTypesRequest serialize() {
-      return Requests.TableTypesRequest.newBuilder().build();
+      Requests.TableTypesRequest.Builder builder = Requests.TableTypesRequest.newBuilder();
+      if (null != connectionId) {
+        builder.setConnectionId(connectionId);
+      }
+
+      return builder.build();
     }
 
     @Override public int hashCode() {
-      return 0;
+      return connectionId == null ? 0 : connectionId.hashCode();
     }
 
     @Override public boolean equals(Object o) {
       if (o == this) {
         return true;
       }
-      return o instanceof TableTypesRequest;
+      if (o instanceof TableTypesRequest) {
+        TableTypesRequest other = (TableTypesRequest) o;
+
+        if (null == connectionId) {
+          if (null != other.connectionId) {
+            return false;
+          }
+        } else if (!connectionId.equals(other.connectionId)) {
+          return false;
+        }
+
+        return true;
+      }
+
+      return false;
     }
   }
 
   /** Request for
-   * {@link Meta#getColumns(String, org.apache.calcite.avatica.Meta.Pat, org.apache.calcite.avatica.Meta.Pat, org.apache.calcite.avatica.Meta.Pat)}.
+   * {@link Meta#getColumns(Meta.ConnectionHandle, String, org.apache.calcite.avatica.Meta.Pat, org.apache.calcite.avatica.Meta.Pat, org.apache.calcite.avatica.Meta.Pat)}.
    */
   class ColumnsRequest extends Request {
+    public final String connectionId;
     public final String catalog;
     public final String schemaPattern;
     public final String tableNamePattern;
     public final String columnNamePattern;
 
     ColumnsRequest() {
+      connectionId = null;
       catalog = null;
       schemaPattern = null;
       tableNamePattern = null;
@@ -472,10 +637,12 @@ public interface Service {
     }
 
     @JsonCreator
-    public ColumnsRequest(@JsonProperty("catalog") String catalog,
+    public ColumnsRequest(@JsonProperty("connectionId") String connectionId,
+        @JsonProperty("catalog") String catalog,
         @JsonProperty("schemaPattern") String schemaPattern,
         @JsonProperty("tableNamePattern") String tableNamePattern,
         @JsonProperty("columnNamePattern") String columnNamePattern) {
+      this.connectionId = connectionId;
       this.catalog = catalog;
       this.schemaPattern = schemaPattern;
       this.tableNamePattern = tableNamePattern;
@@ -494,6 +661,11 @@ public interface Service {
 
       final Requests.ColumnsRequest msg = (Requests.ColumnsRequest) genericMsg;
       final Descriptor desc = msg.getDescriptorForType();
+
+      String connectionId = null;
+      if (ProtobufService.hasField(msg, desc, Requests.ColumnsRequest.CONNECTION_ID_FIELD_NUMBER)) {
+        connectionId = msg.getConnectionId();
+      }
 
       String catalog = null;
       if (ProtobufService.hasField(msg, desc, Requests.ColumnsRequest.CATALOG_FIELD_NUMBER)) {
@@ -518,12 +690,16 @@ public interface Service {
         columnNamePattern = msg.getColumnNamePattern();
       }
 
-      return new ColumnsRequest(catalog, schemaPattern, tableNamePattern, columnNamePattern);
+      return new ColumnsRequest(connectionId, catalog, schemaPattern, tableNamePattern,
+          columnNamePattern);
     }
 
     @Override Requests.ColumnsRequest serialize() {
       Requests.ColumnsRequest.Builder builder = Requests.ColumnsRequest.newBuilder();
 
+      if (null != connectionId) {
+        builder.setConnectionId(connectionId);
+      }
       if (null != catalog) {
         builder.setCatalog(catalog);
       }
@@ -543,6 +719,7 @@ public interface Service {
     @Override public int hashCode() {
       final int prime = 31;
       int result = 1;
+      result = prime * result + ((connectionId == null) ? 0 : connectionId.hashCode());
       result = prime * result + ((catalog == null) ? 0 : catalog.hashCode());
       result = prime * result + ((columnNamePattern == null) ? 0 : columnNamePattern.hashCode());
       result = prime * result + ((schemaPattern == null) ? 0 : schemaPattern.hashCode());
@@ -556,6 +733,14 @@ public interface Service {
       }
       if (o instanceof ColumnsRequest) {
         ColumnsRequest other = (ColumnsRequest) o;
+
+        if (null == connectionId) {
+          if (null != other.connectionId) {
+            return false;
+          }
+        } else if (!connectionId.equals(other.connectionId)) {
+          return false;
+        }
 
         if (null == catalog) {
           if (null != other.catalog) {
@@ -597,8 +782,19 @@ public interface Service {
   }
 
   /** Request for
-   * {@link Meta#getTypeInfo()}. */
+   * {@link Meta#getTypeInfo(Meta.ConnectionHandle)}. */
   class TypeInfoRequest extends Request {
+    public final String connectionId;
+
+    public TypeInfoRequest() {
+      connectionId = null;
+    }
+
+    @JsonCreator
+    public TypeInfoRequest(@JsonProperty("connectionId") String connectionId) {
+      this.connectionId = connectionId;
+    }
+
     @Override ResultSetResponse accept(Service service) {
       return service.apply(this);
     }
@@ -609,22 +805,50 @@ public interface Service {
             "Expected TypeInfoRequest, but got " + genericMsg.getClass().getName());
       }
 
-      return new TypeInfoRequest();
+      final Requests.TypeInfoRequest msg = (Requests.TypeInfoRequest) genericMsg;
+      final Descriptor desc = msg.getDescriptorForType();
+
+      String connectionId = null;
+      if (ProtobufService.hasField(msg, desc,
+          Requests.TypeInfoRequest.CONNECTION_ID_FIELD_NUMBER)) {
+        connectionId = msg.getConnectionId();
+      }
+
+      return new TypeInfoRequest(connectionId);
     }
 
     @Override Requests.TypeInfoRequest serialize() {
-      return Requests.TypeInfoRequest.newBuilder().build();
+      Requests.TypeInfoRequest.Builder builder = Requests.TypeInfoRequest.newBuilder();
+      if (null != connectionId) {
+        builder.setConnectionId(connectionId);
+      }
+
+      return builder.build();
     }
 
     @Override public int hashCode() {
-      return 0;
+      return connectionId == null ? 0 : connectionId.hashCode();
     }
 
     @Override public boolean equals(Object o) {
       if (o == this) {
         return true;
       }
-      return o instanceof TypeInfoRequest;
+      if (o instanceof TypeInfoRequest) {
+        TypeInfoRequest other = (TypeInfoRequest) o;
+
+        if (null == connectionId) {
+          if (null != other.connectionId) {
+            return false;
+          }
+        } else if (!connectionId.equals(other.connectionId)) {
+          return false;
+        }
+
+        return true;
+      }
+
+      return false;
     }
   }
 
@@ -635,10 +859,10 @@ public interface Service {
    * no signature and no other data.
    *
    * <p>Several types of request, including
-   * {@link org.apache.calcite.avatica.Meta#getCatalogs()} and
-   * {@link org.apache.calcite.avatica.Meta#getSchemas(String, org.apache.calcite.avatica.Meta.Pat)}
-   * {@link Meta#getTables(String, Meta.Pat, Meta.Pat, List)}
-   * {@link Meta#getTableTypes()}
+   * {@link org.apache.calcite.avatica.Meta#getCatalogs(Meta.ConnectionHandle)} and
+   * {@link org.apache.calcite.avatica.Meta#getSchemas(Meta.ConnectionHandle, String, org.apache.calcite.avatica.Meta.Pat)}
+   * {@link Meta#getTables(Meta.ConnectionHandle, String, Meta.Pat, Meta.Pat, List)}
+   * {@link Meta#getTableTypes(Meta.ConnectionHandle)}
    * return this response. */
   class ResultSetResponse extends Response {
     public final String connectionId;
@@ -1595,6 +1819,136 @@ public interface Service {
   }
 
   /** Request for
+   * {@link Meta#openConnection}. */
+  class OpenConnectionRequest extends Request {
+    public final String connectionId;
+    public final Map<String, String> info;
+
+    public OpenConnectionRequest() {
+      connectionId = null;
+      info = null;
+    }
+
+    @JsonCreator
+    public OpenConnectionRequest(@JsonProperty("connectionId") String connectionId,
+        @JsonProperty("info") Map<String, String> info) {
+      this.connectionId = connectionId;
+      this.info = info;
+    }
+
+    @Override OpenConnectionResponse accept(Service service) {
+      return service.apply(this);
+    }
+
+    @Override
+    Request deserialize(Message genericMsg) {
+      if (!(genericMsg instanceof Requests.OpenConnectionRequest)) {
+        throw new IllegalArgumentException(
+            "Expected OpenConnectionRequest, but got" + genericMsg.getClass().getName());
+      }
+
+      final Requests.OpenConnectionRequest msg = (Requests.OpenConnectionRequest) genericMsg;
+      final Descriptor desc = msg.getDescriptorForType();
+
+      String connectionId = null;
+      if (ProtobufService.hasField(msg, desc,
+          Requests.OpenConnectionRequest.CONNECTION_ID_FIELD_NUMBER)) {
+        connectionId = msg.getConnectionId();
+      }
+
+      Map<String, String> info = msg.getInfo();
+      if (info.isEmpty()) {
+        info = null;
+      }
+
+      return new OpenConnectionRequest(connectionId, info);
+    }
+
+    @Override
+    Message serialize() {
+      Requests.OpenConnectionRequest.Builder builder = Requests.OpenConnectionRequest.newBuilder();
+      if (null != connectionId) {
+        builder.setConnectionId(connectionId);
+      }
+      if (null != info) {
+        builder.getMutableInfo().putAll(info);
+      }
+
+      return builder.build();
+    }
+
+    @Override public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + ((connectionId == null) ? 0 : connectionId.hashCode());
+      result = prime * result + ((info == null) ? 0 : info.hashCode());
+      return result;
+    }
+
+    @Override public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof OpenConnectionRequest) {
+        OpenConnectionRequest other = (OpenConnectionRequest) o;
+
+        if (null == connectionId) {
+          if (null != other.connectionId) {
+            return false;
+          }
+        } else if (!connectionId.equals(other.connectionId)) {
+          return false;
+        }
+
+        if (null == info) {
+          if (null != other.info) {
+            return false;
+          }
+        } else if (!info.equals(other.info)) {
+          return false;
+        }
+
+        return true;
+      }
+
+      return false;
+    }
+  }
+
+  /** Response from
+   * {@link org.apache.calcite.avatica.remote.Service.OpenConnectionRequest}. */
+  class OpenConnectionResponse extends Response {
+
+    @JsonCreator
+    public OpenConnectionResponse() {
+    }
+
+    @Override OpenConnectionResponse deserialize(Message genericMsg) {
+      if (!(genericMsg instanceof Responses.OpenConnectionResponse)) {
+        throw new IllegalArgumentException(
+            "Expected OpenConnectionResponse, but got " + genericMsg.getClass().getName());
+      }
+
+      return new OpenConnectionResponse();
+    }
+
+    @Override Responses.OpenConnectionResponse serialize() {
+      return Responses.OpenConnectionResponse.newBuilder().build();
+    }
+
+    @Override public int hashCode() {
+      return 0;
+    }
+
+    @Override public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      return o instanceof OpenConnectionResponse;
+    }
+  }
+
+  /** Request for
    * {@link Meta#closeConnection(org.apache.calcite.avatica.Meta.ConnectionHandle)}. */
   class CloseConnectionRequest extends Request {
     public final String connectionId;
@@ -1867,7 +2221,7 @@ public interface Service {
   }
 
   /** Response for
-   * {@link Meta#getDatabaseProperties()}. */
+   * {@link Meta#getDatabaseProperties(Meta.ConnectionHandle)}. */
   class DatabasePropertyResponse extends Response {
     public final Map<Meta.DatabaseProperty, Object> map;
 
@@ -1989,6 +2343,78 @@ public interface Service {
             return false;
           }
         } else if (!map.equals(other.map)) {
+          return false;
+        }
+
+        return true;
+      }
+
+      return false;
+    }
+  }
+
+  /**
+   * ErrorResponse can be used in response to any kind of request. It is used internally
+   * by the transport layers to format errors for transport over the wire.
+   * Thus, {@link Request#apply} will never return an ErrorResponse.
+   */
+  class ErrorResponse extends Response {
+    public final String message;
+
+    public ErrorResponse() {
+      message = null;
+    }
+
+    @JsonCreator
+    public ErrorResponse(@JsonProperty("message") String message) {
+      this.message = message;
+    }
+
+    @Override ErrorResponse deserialize(Message genericMsg) {
+      if (!(genericMsg instanceof Responses.ErrorResponse)) {
+        throw new IllegalArgumentException(
+            "Expected ErrorResponse, but got " + genericMsg.getClass().getName());
+      }
+
+      final Responses.ErrorResponse msg = (Responses.ErrorResponse) genericMsg;
+      final Descriptor desc = msg.getDescriptorForType();
+
+      String message = null;
+      if (ProtobufService.hasField(msg, desc,
+          Responses.ErrorResponse.MESSAGE_FIELD_NUMBER)) {
+        message = msg.getMessage();
+      }
+
+      return new ErrorResponse(message);
+    }
+
+    @Override Responses.ErrorResponse serialize() {
+      Responses.ErrorResponse.Builder builder = Responses.ErrorResponse.newBuilder();
+
+      if (null != message) {
+        builder.setMessage(message);
+      }
+
+      return builder.build();
+    }
+
+    @Override public int hashCode() {
+      return message == null ? 0 : message.hashCode();
+    }
+
+    @Override public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+
+      if (o instanceof ErrorResponse) {
+        ErrorResponse other = (ErrorResponse) o;
+
+        if (null == message) {
+          if (null != other.message) {
+            return false;
+          }
+        } else if (!message.equals(other.message)) {
           return false;
         }
 

--- a/avatica/src/main/protobuf/requests.proto
+++ b/avatica/src/main/protobuf/requests.proto
@@ -22,18 +22,19 @@ import "common.proto";
 
 // Request for Meta#getCatalogs()
 message CatalogsRequest {
-
+  string connection_id = 1;
 }
 
 // Request for Meta#getDatabaseProperties()
 message DatabasePropertyRequest {
-
+  string connection_id = 1;
 }
 
 // Request for Meta#getSchemas(String, org.apache.calcite.avatica.Meta.Pat)}
 message SchemasRequest {
   string catalog = 1;
   string schema_pattern = 2;
+  string connection_id = 3;
 }
 
 // Request for Request for Meta#getTables(String, org.apache.calcite.avatica.Meta.Pat,
@@ -44,11 +45,12 @@ message TablesRequest {
   string table_name_pattern = 3;
   repeated string type_list = 4;
   bool has_type_list = 6; // Having an empty type_list is distinct from a null type_list
+  string connection_id = 7;
 }
 
 // Request for Meta#getTableTypes()
 message TableTypesRequest {
-
+  string connection_id = 1;
 }
 
 // Request for Meta#getColumns(String, org.apache.calcite.avatica.Meta.Pat,
@@ -58,11 +60,12 @@ message ColumnsRequest {
   string schema_pattern = 2;
   string table_name_pattern = 3;
   string column_name_pattern = 4;
+  string connection_id = 5;
 }
 
 // Request for Meta#getTypeInfo()
 message TypeInfoRequest {
-
+  string connection_id = 1;
 }
 
 // Request for Meta#prepareAndExecute(Meta.StatementHandle, String, long, Meta.PrepareCallback)
@@ -99,6 +102,12 @@ message CreateStatementRequest {
 message CloseStatementRequest {
   string connection_id = 1;
   uint32 statement_id = 2;
+}
+
+// Request for Meta#openConnection(Meta.ConnectionHandle, Map<String, String>)
+message OpenConnectionRequest {
+  string connection_id = 1;
+  map<string, string> info = 2;
 }
 
 // Request for Meta#closeConnection(Meta.ConnectionHandle)

--- a/avatica/src/main/protobuf/responses.proto
+++ b/avatica/src/main/protobuf/responses.proto
@@ -57,6 +57,11 @@ message CloseStatementResponse {
 
 }
 
+// Response to OpenConnectionRequest {
+message OpenConnectionResponse {
+
+}
+
 // Response to CloseConnectionRequest {
 message CloseConnectionResponse {
 
@@ -75,4 +80,8 @@ message DatabasePropertyElement {
 // Response for Meta#getDatabaseProperties()
 message DatabasePropertyResponse {
   repeated DatabasePropertyElement props = 1;
+}
+
+message ErrorResponse {
+  string message = 1;
 }

--- a/avatica/src/test/java/org/apache/calcite/avatica/remote/ProtobufTranslationImplTest.java
+++ b/avatica/src/test/java/org/apache/calcite/avatica/remote/ProtobufTranslationImplTest.java
@@ -27,6 +27,7 @@ import org.apache.calcite.avatica.Meta.Style;
 import org.apache.calcite.avatica.MetaImpl;
 import org.apache.calcite.avatica.remote.Service.CatalogsRequest;
 import org.apache.calcite.avatica.remote.Service.CloseConnectionRequest;
+import org.apache.calcite.avatica.remote.Service.CloseConnectionResponse;
 import org.apache.calcite.avatica.remote.Service.CloseStatementRequest;
 import org.apache.calcite.avatica.remote.Service.CloseStatementResponse;
 import org.apache.calcite.avatica.remote.Service.ColumnsRequest;
@@ -36,9 +37,12 @@ import org.apache.calcite.avatica.remote.Service.CreateStatementRequest;
 import org.apache.calcite.avatica.remote.Service.CreateStatementResponse;
 import org.apache.calcite.avatica.remote.Service.DatabasePropertyRequest;
 import org.apache.calcite.avatica.remote.Service.DatabasePropertyResponse;
+import org.apache.calcite.avatica.remote.Service.ErrorResponse;
 import org.apache.calcite.avatica.remote.Service.ExecuteResponse;
 import org.apache.calcite.avatica.remote.Service.FetchRequest;
 import org.apache.calcite.avatica.remote.Service.FetchResponse;
+import org.apache.calcite.avatica.remote.Service.OpenConnectionRequest;
+import org.apache.calcite.avatica.remote.Service.OpenConnectionResponse;
 import org.apache.calcite.avatica.remote.Service.PrepareAndExecuteRequest;
 import org.apache.calcite.avatica.remote.Service.PrepareRequest;
 import org.apache.calcite.avatica.remote.Service.PrepareResponse;
@@ -158,13 +162,13 @@ public class ProtobufTranslationImplTest<T> {
 
     requests.add(new CatalogsRequest());
     requests.add(new DatabasePropertyRequest());
-    requests.add(new SchemasRequest("catalog", "schemaPattern"));
+    requests.add(new SchemasRequest("connectionId", "catalog", "schemaPattern"));
     requests.add(
-        new TablesRequest("catalog", "schemaPattern", "tableNamePattern",
+        new TablesRequest("connectionId", "catalog", "schemaPattern", "tableNamePattern",
             Arrays.asList("STRING", "BOOLEAN", "INT")));
     requests.add(new TableTypesRequest());
     requests.add(
-        new ColumnsRequest("catalog", "schemaPattern", "tableNamePattern",
+        new ColumnsRequest("connectionId", "catalog", "schemaPattern", "tableNamePattern",
             "columnNamePattern"));
     requests.add(new TypeInfoRequest());
     requests.add(
@@ -181,6 +185,10 @@ public class ProtobufTranslationImplTest<T> {
 
     requests.add(new CreateStatementRequest("connectionId"));
     requests.add(new CloseStatementRequest("connectionId", Integer.MAX_VALUE));
+    Map<String, String> info = new HashMap<>();
+    info.put("param1", "value1");
+    info.put("param2", "value2");
+    requests.add(new OpenConnectionRequest("connectionId", info));
     requests.add(new CloseConnectionRequest("connectionId"));
     requests.add(
         new ConnectionSyncRequest("connectionId",
@@ -194,14 +202,15 @@ public class ProtobufTranslationImplTest<T> {
     LinkedList<Request> requests = new LinkedList<>();
 
     // We're pretty fast and loose on what can be null.
-    requests.add(new SchemasRequest(null, null));
+    requests.add(new SchemasRequest(null, null, null));
     // Repeated fields default to an empty list
-    requests.add(new TablesRequest(null, null, null, Collections.<String>emptyList()));
-    requests.add(new ColumnsRequest(null, null, null, null));
+    requests.add(new TablesRequest(null, null, null, null, Collections.<String>emptyList()));
+    requests.add(new ColumnsRequest(null, null, null, null, null));
     requests.add(new PrepareAndExecuteRequest(null, 0, null, 0));
     requests.add(new PrepareRequest(null, null, 0));
     requests.add(new CreateStatementRequest(null));
     requests.add(new CloseStatementRequest(null, 0));
+    requests.add(new OpenConnectionRequest(null, null));
     requests.add(new CloseConnectionRequest(null));
     requests.add(new ConnectionSyncRequest(null, null));
 
@@ -245,6 +254,9 @@ public class ProtobufTranslationImplTest<T> {
         Integer.MAX_VALUE, "catalog", "schema");
     responses.add(new ConnectionSyncResponse(connProps));
 
+    responses.add(new OpenConnectionResponse());
+    responses.add(new CloseConnectionResponse());
+
     responses.add(new CreateStatementResponse("connectionId", Integer.MAX_VALUE));
 
     Map<Meta.DatabaseProperty, Object> propertyMap = new HashMap<>();
@@ -259,6 +271,8 @@ public class ProtobufTranslationImplTest<T> {
         new PrepareResponse(
             new Meta.StatementHandle("connectionId", Integer.MAX_VALUE,
                 signature)));
+
+    responses.add(new ErrorResponse("an error occurred"));
 
     return responses;
   }

--- a/avatica/src/test/java/org/apache/calcite/avatica/test/JsonHandlerTest.java
+++ b/avatica/src/test/java/org/apache/calcite/avatica/test/JsonHandlerTest.java
@@ -85,6 +85,10 @@ public class JsonHandlerTest {
       return null;
     }
 
+    @Override public OpenConnectionResponse apply(OpenConnectionRequest request) {
+      return null;
+    }
+
     @Override public CloseConnectionResponse apply(CloseConnectionRequest request) {
       return null;
     }

--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteMetaImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteMetaImpl.java
@@ -214,7 +214,7 @@ public class CalciteMetaImpl extends MetaImpl {
     return (CalciteConnectionImpl) connection;
   }
 
-  @Override public Map<DatabaseProperty, Object> getDatabaseProperties() {
+  @Override public Map<DatabaseProperty, Object> getDatabaseProperties(ConnectionHandle ch) {
     final ImmutableMap.Builder<DatabaseProperty, Object> builder =
         ImmutableMap.builder();
     for (DatabaseProperty p : DatabaseProperty.values()) {
@@ -243,7 +243,8 @@ public class CalciteMetaImpl extends MetaImpl {
     }
   }
 
-  public MetaResultSet getTables(String catalog,
+  public MetaResultSet getTables(ConnectionHandle ch,
+      String catalog,
       final Pat schemaPattern,
       final Pat tableNamePattern,
       final List<String> typeList) {
@@ -280,7 +281,7 @@ public class CalciteMetaImpl extends MetaImpl {
         "REF_GENERATION");
   }
 
-  public MetaResultSet getTypeInfo() {
+  public MetaResultSet getTypeInfo(ConnectionHandle ch) {
     return createResultSet(allTypeInfo(),
         MetaTypeInfo.class,
         "TYPE_NAME",
@@ -303,7 +304,8 @@ public class CalciteMetaImpl extends MetaImpl {
         "NUM_PREC_RADIX");
   }
 
-  public MetaResultSet getColumns(String catalog,
+  public MetaResultSet getColumns(ConnectionHandle ch,
+      String catalog,
       Pat schemaPattern,
       Pat tableNamePattern,
       Pat columnNamePattern) {
@@ -506,7 +508,7 @@ public class CalciteMetaImpl extends MetaImpl {
             });
   }
 
-  public MetaResultSet getSchemas(String catalog, Pat schemaPattern) {
+  public MetaResultSet getSchemas(ConnectionHandle ch, String catalog, Pat schemaPattern) {
     final Predicate1<MetaSchema> schemaMatcher = namedMatcher(schemaPattern);
     return createResultSet(schemas(catalog).where(schemaMatcher),
         MetaSchema.class,
@@ -514,13 +516,13 @@ public class CalciteMetaImpl extends MetaImpl {
         "TABLE_CATALOG");
   }
 
-  public MetaResultSet getCatalogs() {
+  public MetaResultSet getCatalogs(ConnectionHandle ch) {
     return createResultSet(catalogs(),
         MetaCatalog.class,
         "TABLE_CAT");
   }
 
-  public MetaResultSet getTableTypes() {
+  public MetaResultSet getTableTypes(ConnectionHandle ch) {
     return createResultSet(tableTypes(),
         MetaTableType.class,
         "TABLE_TYPE");

--- a/pom.xml
+++ b/pom.xml
@@ -317,6 +317,12 @@ limitations under the License.
         <artifactId>xalan</artifactId>
         <version>2.7.1</version>
       </dependency>
+      <dependency>
+        <groupId>com.github.stephenc.jcip</groupId>
+        <artifactId>jcip-annotations</artifactId>
+        <version>1.0-1</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
### About

An update of the patch I previously attached to the ticket, now based on master which means it includes the protocol buffer stuff (part of the diff is just generated protocol buffer code).

I think I processed the remarks given on the earlier patch, and I'm not aware of any hacks in the current patch, just let me know if there are any issues.

The new dependency on jcip is to disable parallel test execution in surefire for a single test class, the test testConnectionIsolation which is inspecting the server-side connections is inherently not thread safe, not sure why worked before.

### Commit message

Goal: passing of connection properties (the 'info') from the remote avatica driver to the corresponding server-side connection.

Changes include:
 * in Meta: explicit opening of connections: there is a new openConnection() call. Client decides on the connection id. Implicit creation of unknown connections is gone.
 * JdbcMeta: default connection is gone, all methods have been extended with a connection id.
 * correspondingly, the various Service.Request's now carry a connection id (will make fixing CALCITE-871 easy)
 * (unrelated, but was useful for testing) more meaningful error messages in remote driver