### PR TITLE
[CALCITE-925] Improving optimization using Materialized Views [CALCITE-786] by allowing strings and predicates that specify ranges.

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RexImplicationChecker.java
+++ b/core/src/main/java/org/apache/calcite/plan/RexImplicationChecker.java
@@ -32,11 +32,14 @@ import org.apache.calcite.sql.fun.SqlCastFunction;
 import org.apache.calcite.util.Pair;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Checks whether one condition logically implies another.
@@ -151,25 +154,46 @@ public class RexImplicationChecker {
       return false;
     }
 
-    List<Pair<RexInputRef, RexNode>> usageList = new ArrayList<>();
+    ImmutableList.Builder<Set<Pair<RexInputRef, RexNode>>> usagesBuilder =
+        ImmutableList.builder();
     for (Map.Entry<RexInputRef, InputRefUsage<SqlOperator, RexNode>> entry
         : firstUsageFinder.usageMap.entrySet()) {
-      final Pair<SqlOperator, RexNode> pair = entry.getValue().usageList.get(0);
-      usageList.add(Pair.of(entry.getKey(), pair.getValue()));
+      ImmutableSet.Builder<Pair<RexInputRef, RexNode>> usageBuilder =
+          ImmutableSet.builder();
+      if (entry.getValue().usageList.size() > 0) {
+        for (final Pair<SqlOperator, RexNode> pair
+            : entry.getValue().usageList) {
+          usageBuilder.add(Pair.of(entry.getKey(), pair.getValue()));
+        }
+        usagesBuilder.add(usageBuilder.build());
+      }
     }
 
-    // Get the literals from first conjunction and executes second conjunction
-    // using them.
-    //
-    // E.g., for
-    //   x > 30 &rArr; x > 10,
-    // we will replace x by 30 in second expression and execute it i.e.,
-    //   30 > 10
-    //
-    // If it's true then we infer implication.
-    final DataContext dataValues =
-        VisitorDataContext.of(rowType, usageList);
+    final Set<List<Pair<RexInputRef, RexNode>>> usages =
+        Sets.cartesianProduct(usagesBuilder.build());
 
+    for (List usageList : usages) {
+      // Get the literals from first conjunction and executes second conjunction
+      // using them.
+      //
+      // E.g., for
+      //   x > 30 &rArr; x > 10,
+      // we will replace x by 30 in second expression and execute it i.e.,
+      //   30 > 10
+      //
+      // If it's true then we infer implication.
+      final DataContext dataValues =
+          VisitorDataContext.of(rowType, usageList);
+
+      if (!isSatisfiable(second, dataValues)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private boolean isSatisfiable(RexNode second, DataContext dataValues) {
     if (dataValues == null) {
       return false;
     }
@@ -215,6 +239,10 @@ public class RexImplicationChecker {
    *    <li>(=) X (>, >=, <, <=, =, !=)
    *    <li>(!=, =)
    * </ul>
+   *
+   * <li>We support utmost 2 operators to be be used for a variable in first
+   * and second usages
+   *
    * </ol>
    *
    * @return whether input usage pattern is supported
@@ -227,52 +255,100 @@ public class RexImplicationChecker {
         secondUsageFinder.usageMap;
 
     for (Map.Entry<RexInputRef, InputRefUsage<SqlOperator, RexNode>> entry
-        : firstUsageMap.entrySet()) {
-      if (entry.getValue().usageCount > 1) {
-        return false;
-      }
-    }
-
-    for (Map.Entry<RexInputRef, InputRefUsage<SqlOperator, RexNode>> entry
         : secondUsageMap.entrySet()) {
       final InputRefUsage<SqlOperator, RexNode> secondUsage = entry.getValue();
-      if (secondUsage.usageCount > 1
-          || secondUsage.usageList.size() != 1) {
+      final List<Pair<SqlOperator, RexNode>> secondUsageList = secondUsage.usageList;
+      final int secondLen = secondUsageList.size();
+
+      if (secondUsage.usageCount != secondLen || secondLen > 2) {
         return false;
       }
 
       final InputRefUsage<SqlOperator, RexNode> firstUsage =
           firstUsageMap.get(entry.getKey());
+
       if (firstUsage == null
-          || firstUsage.usageList.size() != 1) {
+          || firstUsage.usageList.size() != firstUsage.usageCount
+          || firstUsage.usageCount > 2) {
         return false;
       }
 
-      final Pair<SqlOperator, RexNode> fUse = firstUsage.usageList.get(0);
-      final Pair<SqlOperator, RexNode> sUse = secondUsage.usageList.get(0);
+      final List<Pair<SqlOperator, RexNode>> firstUsageList = firstUsage.usageList;
+      final int firstLen = firstUsageList.size();
 
-      final SqlKind fKind = fUse.getKey().getKind();
+      final SqlKind fKind = firstUsageList.get(0).getKey().getKind();
+      final SqlKind sKind = secondUsageList.get(0).getKey().getKind();
+      final SqlKind fKind2 =
+          (firstUsageList.size() == 2) ? firstUsageList.get(1).getKey().getKind() : null;
+      final SqlKind sKind2 =
+          (secondUsageList.size() == 2) ? secondUsageList.get(1).getKey().getKind() : null;
 
-      if (fKind != SqlKind.EQUALS) {
-        switch (sUse.getKey().getKind()) {
-        case GREATER_THAN:
-        case GREATER_THAN_OR_EQUAL:
-          if (!(fKind == SqlKind.GREATER_THAN)
-              && !(fKind == SqlKind.GREATER_THAN_OR_EQUAL)) {
-            return false;
-          }
-          break;
-        case LESS_THAN:
-        case LESS_THAN_OR_EQUAL:
-          if (!(fKind == SqlKind.LESS_THAN)
-              && !(fKind == SqlKind.LESS_THAN_OR_EQUAL)) {
-            return false;
-          }
-          break;
-        default:
+      if (firstLen == 2 && secondLen == 2
+          && !(isEquivalentOp(fKind, sKind) && isEquivalentOp(fKind2, sKind2))
+          && !(isEquivalentOp(fKind, sKind2) && isEquivalentOp(fKind2, sKind))) {
+        return false;
+      } else if (firstLen == 1 && secondLen == 1
+          && fKind != SqlKind.EQUALS && !isEquivalentOp(fKind, sKind)) {
+        return false;
+      } else if (firstLen == 1 && secondLen == 2 && fKind != SqlKind.EQUALS) {
+        return false;
+      } else if (firstLen == 2 && secondLen == 1) {
+        // Allow only cases like
+        // x < 30 and x < 40 implies x < 70
+        // x > 30 and x < 40 implies x < 70
+        // But disallow cases like
+        // x > 30 and x > 40 implies x < 70
+        if (!isOppositeOp(fKind, fKind2)
+            && !(isEquivalentOp(fKind, fKind2) && isEquivalentOp(fKind, sKind))) {
           return false;
         }
       }
+    }
+
+    return true;
+  }
+
+  private boolean isEquivalentOp(SqlKind fKind, SqlKind sKind) {
+    switch (sKind) {
+    case GREATER_THAN:
+    case GREATER_THAN_OR_EQUAL:
+      if (!(fKind == SqlKind.GREATER_THAN)
+          && !(fKind == SqlKind.GREATER_THAN_OR_EQUAL)) {
+        return false;
+      }
+      break;
+    case LESS_THAN:
+    case LESS_THAN_OR_EQUAL:
+      if (!(fKind == SqlKind.LESS_THAN)
+          && !(fKind == SqlKind.LESS_THAN_OR_EQUAL)) {
+        return false;
+      }
+      break;
+    default:
+      return false;
+    }
+
+    return true;
+  }
+
+  private boolean isOppositeOp(SqlKind fKind, SqlKind sKind) {
+    switch (sKind) {
+    case GREATER_THAN:
+    case GREATER_THAN_OR_EQUAL:
+      if (!(fKind == SqlKind.LESS_THAN)
+          && !(fKind == SqlKind.LESS_THAN_OR_EQUAL)) {
+        return false;
+      }
+      break;
+    case LESS_THAN:
+    case LESS_THAN_OR_EQUAL:
+      if (!(fKind == SqlKind.GREATER_THAN)
+          && !(fKind == SqlKind.GREATER_THAN_OR_EQUAL)) {
+        return false;
+      }
+      break;
+    default:
+      return false;
     }
     return true;
   }

--- a/core/src/test/java/org/apache/calcite/test/RexImplicationCheckerTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RexImplicationCheckerTest.java
@@ -197,6 +197,41 @@ public class RexImplicationCheckerTest {
     f.checkNotImplies(node2, node1);
   }
 
+  @Test public void testSimpleBetween() {
+    final Fixture f = new Fixture();
+    final RexNode node1 = f.ge(f.i, f.literal(30));
+    final RexNode node2 = f.lt(f.i, f.literal(70));
+    final RexNode node3 = f.and(node1, node2);
+    final RexNode node4 = f.ge(f.i, f.literal(50));
+    final RexNode node5 = f.lt(f.i, f.literal(60));
+    final RexNode node6 = f.and(node4, node5);
+
+    f.checkNotImplies(node3, node4);
+    f.checkNotImplies(node3, node5);
+    f.checkNotImplies(node3, node6);
+    f.checkNotImplies(node1, node6);
+    f.checkNotImplies(node2, node6);
+    f.checkImplies(node6, node3);
+    f.checkImplies(node6, node2);
+    f.checkImplies(node6, node1);
+  }
+
+  @Test public void testSimpleBetweenCornerCases() {
+    final Fixture f = new Fixture();
+    final RexNode node1 = f.gt(f.i, f.literal(30));
+    final RexNode node2 = f.gt(f.i, f.literal(50));
+    final RexNode node3 = f.lt(f.i, f.literal(60));
+    final RexNode node4 = f.lt(f.i, f.literal(80));
+    final RexNode node5 = f.lt(f.i, f.literal(90));
+    final RexNode node6 = f.lt(f.i, f.literal(100));
+
+    f.checkNotImplies(f.and(node1, node2), f.and(node3, node4));
+    f.checkNotImplies(f.and(node5, node6), f.and(node3, node4));
+    f.checkNotImplies(f.and(node1, node2), node6);
+    f.checkNotImplies(node6, f.and(node1, node2));
+    f.checkImplies(f.and(node3, node4), f.and(node5, node6));
+  }
+
   /** Contains all the nourishment a test case could possibly need.
    *
    * <p>We put the data in here, rather than as fields in the test case, so that
@@ -324,6 +359,10 @@ public class RexImplicationCheckerTest {
     RexNode le(RexNode node1, RexNode node2) {
       return rexBuilder.makeCall(SqlStdOperatorTable.LESS_THAN_OR_EQUAL, node1,
           node2);
+    }
+
+    RexNode and(RexNode node1, RexNode node2) {
+      return rexBuilder.makeCall(SqlStdOperatorTable.AND, node1, node2);
     }
 
     RexNode longLiteral(long value) {

--- a/core/src/test/java/org/apache/calcite/test/RexImplicationCheckerTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RexImplicationCheckerTest.java
@@ -164,6 +164,13 @@ public class RexImplicationCheckerTest {
     f.checkNotImplies(node2, node1);
   }
 
+  @Test public void testSimpleString() {
+    final Fixture f = new Fixture();
+    final RexNode node1 = f.eq(f.str, f.rexBuilder.makeLiteral("en"));
+
+    f.checkImplies(node1, node1);
+  }
+
   @Ignore("work in progress")
   @Test public void testSimpleDate() {
     final Fixture f = new Fixture();
@@ -250,6 +257,7 @@ public class RexImplicationCheckerTest {
     private final RexNode ch;
     private final RexNode ts;
     private final RexNode t;
+    private final RexNode str;
 
     private final RelDataType boolRelDataType;
     private final RelDataType intRelDataType;
@@ -262,6 +270,7 @@ public class RexImplicationCheckerTest {
     private final RelDataType dateDataType;
     private final RelDataType timeStampDataType;
     private final RelDataType timeDataType;
+    private final RelDataType stringDataType;
     private final RelDataTypeFactory typeFactory;
     private final RexImplicationChecker checker;
     private final RelDataType rowType;
@@ -281,6 +290,7 @@ public class RexImplicationCheckerTest {
       dateDataType = typeFactory.createJavaType(Date.class);
       timeStampDataType = typeFactory.createJavaType(Timestamp.class);
       timeDataType = typeFactory.createJavaType(Time.class);
+      stringDataType = typeFactory.createJavaType(String.class);
 
       bl = ref(0, this.boolRelDataType);
       i = ref(1, intRelDataType);
@@ -293,6 +303,7 @@ public class RexImplicationCheckerTest {
       dt = ref(8, dateDataType);
       ts = ref(9, timeStampDataType);
       t = ref(10, timeDataType);
+      str = ref(11, stringDataType);
 
       rowType = typeFactory.builder()
           .add("bool", this.boolRelDataType)
@@ -306,6 +317,7 @@ public class RexImplicationCheckerTest {
           .add("date", dateDataType)
           .add("timestamp", timeStampDataType)
           .add("time", timeDataType)
+          .add("string", stringDataType)
           .build();
 
       final Holder<RexExecutorImpl> holder = Holder.of(null);


### PR DESCRIPTION
1. Partition optimization now supports specifying partitions using
    predicates specifying intervals on variables, for e.g., 'x<90 and x>30'.
    Queries containing such interval predicates will also be optimized.

2. Added support to String data type for Partitions.

Testing: 
Travis build successful on qubole's fork of master branch:  https://travis-ci.org/qubole/incubator-calcite/builds/86120945